### PR TITLE
Update BlockEntityUpdater.java

### DIFF
--- a/src/main/java/thut/api/entity/blockentity/BlockEntityUpdater.java
+++ b/src/main/java/thut/api/entity/blockentity/BlockEntityUpdater.java
@@ -94,11 +94,7 @@ public class BlockEntityUpdater
                     if (shape.isEmpty()) continue;
                     shape = shape.withOffset(mob.getPosX() + i - dx, mob.getPosY() + j + min.getY(), mob.getPosZ() + k
                             - dz);
-                    for (final AxisAlignedBB box : shape.toBoundingBoxList())
-                    {
-                        shape = VoxelShapes.create(box);
-                        this.totalShape = VoxelShapes.combineAndSimplify(this.totalShape, shape, IBooleanFunction.OR);
-                    }
+                    this.totalShape = VoxelShapes.combineAndSimplify(this.totalShape, shape, IBooleanFunction.OR);
                 }
         return this.totalShape;
     }


### PR DESCRIPTION
simplifies this, the split wasn't needed anymore (was leftover from when this checked other boxes)