### PR TITLE
Map Colors (#617)

### DIFF
--- a/src/main/java/pokecube/adventures/PokecubeAdv.java
+++ b/src/main/java/pokecube/adventures/PokecubeAdv.java
@@ -7,6 +7,7 @@ import com.google.common.collect.Maps;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.ai.attributes.AttributeModifierMap;
@@ -191,21 +192,21 @@ public class PokecubeAdv
 
         // Blocks
         AFA = PokecubeAdv.BLOCKS.register("afa", () -> new AfaBlock(Block.Properties.create(Material.IRON)
-                .variableOpacity()));
+                .variableOpacity(), MaterialColor.BLACK));
         COMMANDER = PokecubeAdv.BLOCKS.register("commander", () -> new CommanderBlock(Block.Properties.create(
-                Material.IRON).variableOpacity()));
+                Material.IRON).variableOpacity(), MaterialColor.BLACK));
         DAYCARE = PokecubeAdv.BLOCKS.register("daycare", () -> new DaycareBlock(Block.Properties.create(Material.IRON)
-                .variableOpacity()));
+        		.variableOpacity(), MaterialColor.BLACK));
         CLONER = PokecubeAdv.BLOCKS.register("cloner", () -> new ClonerBlock(Block.Properties.create(Material.IRON)
-                .variableOpacity()));
+                .variableOpacity(), MaterialColor.PURPLE));
         EXTRACTOR = PokecubeAdv.BLOCKS.register("extractor", () -> new ExtractorBlock(Block.Properties.create(
-                Material.IRON).variableOpacity()));
+                Material.IRON).variableOpacity(), MaterialColor.CYAN));
         SPLICER = PokecubeAdv.BLOCKS.register("splicer", () -> new SplicerBlock(Block.Properties.create(Material.IRON)
-                .variableOpacity()));
+                .variableOpacity(), MaterialColor.CYAN));
         SIPHON = PokecubeAdv.BLOCKS.register("siphon", () -> new SiphonBlock(Block.Properties.create(Material.IRON)
-                .variableOpacity()));
+                .variableOpacity(), MaterialColor.GREEN_TERRACOTTA));
         WARPPAD = PokecubeAdv.BLOCKS.register("warppad", () -> new WarppadBlock(Block.Properties.create(
-                Material.IRON)));
+                Material.IRON), MaterialColor.WHITE_TERRACOTTA));
 
         // Items
         EXPSHARE = PokecubeAdv.ITEMS.register("exp_share", () -> new Item(new Item.Properties().group(

--- a/src/main/java/pokecube/adventures/blocks/afa/AfaBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/afa/AfaBlock.java
@@ -1,6 +1,7 @@
 package pokecube.adventures.blocks.afa;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockReader;
 import pokecube.core.blocks.InteractableHorizontalBlock;
@@ -8,9 +9,9 @@ import pokecube.core.blocks.InteractableHorizontalBlock;
 public class AfaBlock extends InteractableHorizontalBlock
 {
 
-    public AfaBlock(final Properties properties)
+    public AfaBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
     }
 
     @Override

--- a/src/main/java/pokecube/adventures/blocks/commander/CommanderBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/commander/CommanderBlock.java
@@ -2,6 +2,7 @@ package pokecube.adventures.blocks.commander;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;
@@ -12,9 +13,9 @@ import pokecube.core.interfaces.PokecubeMod;
 public class CommanderBlock extends InteractableHorizontalBlock
 {
 
-    public CommanderBlock(final Properties properties)
+    public CommanderBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
     }
 
     @Override

--- a/src/main/java/pokecube/adventures/blocks/daycare/DaycareBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/daycare/DaycareBlock.java
@@ -1,6 +1,7 @@
 package pokecube.adventures.blocks.daycare;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.math.BlockPos;
@@ -10,9 +11,9 @@ import pokecube.core.blocks.InteractableHorizontalBlock;
 public class DaycareBlock extends InteractableHorizontalBlock
 {
 
-    public DaycareBlock(final Properties properties)
+    public DaycareBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
     }
 
     @Override

--- a/src/main/java/pokecube/adventures/blocks/genetics/cloner/ClonerBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/genetics/cloner/ClonerBlock.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.FluidState;
@@ -51,9 +52,9 @@ public class ClonerBlock extends InteractableHorizontalBlock implements IWaterLo
     }
 
     // Default States
-    public ClonerBlock(final Properties properties)
+    public ClonerBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(ClonerBlock.HALF, ClonerBlockPart.BOTTOM).with(
                 HorizontalBlock.HORIZONTAL_FACING, Direction.NORTH).with(ClonerBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/adventures/blocks/genetics/extractor/ExtractorBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/genetics/extractor/ExtractorBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.BlockItemUseContext;
@@ -85,9 +86,9 @@ public class ExtractorBlock extends InteractableHorizontalBlock implements IWate
         return ExtractorBlock.EXTRACTOR.get(state.get(ExtractorBlock.FACING));
     }
     
-    public ExtractorBlock(final Properties properties)
+    public ExtractorBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(ExtractorBlock.FACING, Direction.NORTH).with(
         		ExtractorBlock.FIXED, false).with(WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/adventures/blocks/genetics/splicer/SplicerBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/genetics/splicer/SplicerBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -119,9 +120,9 @@ public class SplicerBlock extends InteractableHorizontalBlock implements IWaterL
         return SplicerBlock.SPLICER.get(state.get(SplicerBlock.FACING));
     }
 
-    public SplicerBlock(final Properties properties)
+    public SplicerBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(SplicerBlock.FACING, Direction.NORTH).with(
                 SplicerBlock.FIXED, false).with(WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/adventures/blocks/siphon/SiphonBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/siphon/SiphonBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -86,9 +87,9 @@ public class SiphonBlock extends InteractableHorizontalBlock implements IWaterLo
         return SiphonBlock.SIPHON.get(state.get(SiphonBlock.FACING));
     }
     
-    public SiphonBlock(final Properties properties)
+    public SiphonBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(SiphonBlock.FACING, Direction.NORTH).with(
         		SiphonBlock.FIXED, false).with(WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/adventures/blocks/warppad/WarppadBlock.java
+++ b/src/main/java/pokecube/adventures/blocks/warppad/WarppadBlock.java
@@ -1,6 +1,7 @@
 package pokecube.adventures.blocks.warppad;
 
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.world.IBlockReader;
 import pokecube.core.blocks.InteractableHorizontalBlock;
@@ -8,9 +9,9 @@ import pokecube.core.blocks.InteractableHorizontalBlock;
 public class WarppadBlock extends InteractableHorizontalBlock
 {
 
-    public WarppadBlock(final Properties properties)
+    public WarppadBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
     }
 
     @Override

--- a/src/main/java/pokecube/core/PokecubeItems.java
+++ b/src/main/java/pokecube/core/PokecubeItems.java
@@ -24,6 +24,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItem;
 import net.minecraft.item.Food;
 import net.minecraft.item.Item;
@@ -194,25 +195,25 @@ public class PokecubeItems extends ItemList
 
         // Blocks
         HEALER = PokecubeItems.BLOCKS.register("pokecenter", () -> new HealerBlock(Block.Properties.create(
-                Material.IRON).hardnessAndResistance(2000)));
+                Material.IRON, MaterialColor.WOOL).hardnessAndResistance(2000)));
         NESTBLOCK = PokecubeItems.BLOCKS.register("nest", () -> new NestBlock(Block.Properties.create(
-                Material.ORGANIC)));
+                Material.ORGANIC, MaterialColor.STONE)));
         REPELBLOCK = PokecubeItems.BLOCKS.register("repel", () -> new RepelBlock(Block.Properties.create(
-                Material.ORGANIC)));
+                Material.ORGANIC, MaterialColor.GREEN)));
         DYNABLOCK = PokecubeItems.BLOCKS.register("dynamax", () -> new MaxBlock(Block.Properties.create(Material.ROCK)
-                .hardnessAndResistance(2000)));
-        PCTOP = PokecubeItems.BLOCKS.register("pc_top", () -> new PCBlock(Block.Properties.create(Material.IRON)
+                .hardnessAndResistance(2000), MaterialColor.BLACK));
+        PCTOP = PokecubeItems.BLOCKS.register("pc_top", () -> new PCBlock(Block.Properties.create(Material.IRON, MaterialColor.RED)
                 .hardnessAndResistance(2000), true));
-        PCBASE = PokecubeItems.BLOCKS.register("pc_base", () -> new PCBlock(Block.Properties.create(Material.IRON)
+        PCBASE = PokecubeItems.BLOCKS.register("pc_base", () -> new PCBlock(Block.Properties.create(Material.IRON, MaterialColor.RED)
                 .hardnessAndResistance(2000), false));
         TMMACHINE = PokecubeItems.BLOCKS.register("tm_machine", () -> new TMBlock(Block.Properties.create(Material.IRON)
-                .hardnessAndResistance(2000)));
+                .hardnessAndResistance(2000), MaterialColor.LIGHT_BLUE));
         TRADER = PokecubeItems.BLOCKS.register("trade_machine", () -> new TraderBlock(Block.Properties.create(
-                Material.IRON).hardnessAndResistance(2000)));
+                Material.IRON).hardnessAndResistance(2000), MaterialColor.GRAY_TERRACOTTA));
         SECRETBASE = PokecubeItems.BLOCKS.register("secret_base", () -> new BaseBlock(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(2000)));
+                Material.ROCK, MaterialColor.STONE).hardnessAndResistance(2000)));
         FOSSILSTONE = PokecubeItems.BLOCKS.register("fossilstone", () -> new Block(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(1.5f, 10).harvestTool(ToolType.PICKAXE)));
+                Material.ROCK, MaterialColor.STONE).hardnessAndResistance(1.5f, 10).harvestTool(ToolType.PICKAXE)));
 
         // Tile Entity Types
         NEST_TYPE = PokecubeItems.TILES.register("nest", () -> TileEntityType.Builder.create(NestTile::new,

--- a/src/main/java/pokecube/core/blocks/InteractableBlock.java
+++ b/src/main/java/pokecube/core/blocks/InteractableBlock.java
@@ -2,6 +2,7 @@ package pokecube.core.blocks;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;

--- a/src/main/java/pokecube/core/blocks/InteractableHorizontalBlock.java
+++ b/src/main/java/pokecube/core/blocks/InteractableHorizontalBlock.java
@@ -4,6 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.inventory.IInventory;
@@ -25,9 +26,9 @@ import net.minecraftforge.items.IItemHandler;
 public abstract class InteractableHorizontalBlock extends HorizontalBlock
 {
 
-    public InteractableHorizontalBlock(final Properties properties)
+    public InteractableHorizontalBlock(final Properties properties, final MaterialColor color)
     {
-        super(Properties.create(Material.IRON).hardnessAndResistance(3.0f, 5.0f).harvestTool(ToolType.PICKAXE));
+        super(Properties.create(Material.IRON, color).hardnessAndResistance(3.0f, 5.0f).harvestTool(ToolType.PICKAXE));
         this.setDefaultState(this.stateContainer.getBaseState().with(HorizontalBlock.HORIZONTAL_FACING,
                 Direction.NORTH));
     }

--- a/src/main/java/pokecube/core/blocks/maxspot/MaxBlock.java
+++ b/src/main/java/pokecube/core/blocks/maxspot/MaxBlock.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -113,9 +114,9 @@ public class MaxBlock extends InteractableHorizontalBlock
         return MaxBlock.DYNAMAX.get(state.get(MaxBlock.FACING));
     }
 
-    public MaxBlock(final Properties properties)
+    public MaxBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(MaxBlock.FACING, Direction.NORTH).with(
                 MaxBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/core/blocks/repel/RepelBlock.java
+++ b/src/main/java/pokecube/core/blocks/repel/RepelBlock.java
@@ -2,6 +2,7 @@ package pokecube.core.blocks.repel;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.IBlockReader;

--- a/src/main/java/pokecube/core/blocks/tms/TMBlock.java
+++ b/src/main/java/pokecube/core/blocks/tms/TMBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -114,9 +115,9 @@ public class TMBlock extends InteractableHorizontalBlock implements IWaterLoggab
         return TMBlock.TM_MACHINE.get(state.get(TMBlock.FACING));
     }
 
-    public TMBlock(final Properties properties)
+    public TMBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(TMBlock.FACING, Direction.NORTH).with(
                 TMBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/core/blocks/trade/TraderBlock.java
+++ b/src/main/java/pokecube/core/blocks/trade/TraderBlock.java
@@ -8,6 +8,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -97,9 +98,9 @@ public class TraderBlock extends InteractableHorizontalBlock implements IWaterLo
         return TraderBlock.TRADER_BLOCK.get(state.get(TraderBlock.FACING));
     }
 
-    public TraderBlock(final Properties properties)
+    public TraderBlock(final Properties properties, final MaterialColor color)
     {
-        super(properties);
+        super(properties, color);
         this.setDefaultState(this.stateContainer.getBaseState().with(TraderBlock.FACING, Direction.NORTH).with(
                 TraderBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/core/handlers/ItemGenerator.java
+++ b/src/main/java/pokecube/core/handlers/ItemGenerator.java
@@ -64,9 +64,11 @@ public class ItemGenerator
 
     public static Map<String, ItemFossil> fossils = Maps.newHashMap();
 
+    public static final Map<String, MaterialColor> berryCrops = Maps.newHashMap();
+    public static final Map<String, MaterialColor> berryFruits = Maps.newHashMap();
+    public static final Map<String, MaterialColor> berryLeaves = Maps.newHashMap();
     public static final Map<String, MaterialColor> berryWoods = Maps.newHashMap();
-
-    public static final List<String> onlyBerryLeaves = Lists.newArrayList();
+    public static final Map<String, MaterialColor> onlyBerryLeaves = Maps.newHashMap();
 
     public static Map<String, Block> leaves          = Maps.newHashMap();
     public static Map<String, Block> logs            = Maps.newHashMap();
@@ -113,14 +115,14 @@ public class ItemGenerator
             final String name = BerryManager.berryNames.get(index);
 
             // Crop
-            Block block = new BerryCrop(Block.Properties.create(Material.PLANTS).doesNotBlockMovement().tickRandomly()
+            Block block = new BerryCrop(Block.Properties.create(Material.PLANTS, berryFruits.get(name)).doesNotBlockMovement().tickRandomly()
                     .hardnessAndResistance(0.0F).notSolid().sound(SoundType.CROP), index);
             block.setRegistryName(PokecubeCore.MODID, "crop_" + name);
             BerryManager.berryCrops.put(index, block);
             registry.register(block);
 
             // Fruit
-            block = new BerryFruit(Block.Properties.create(Material.PLANTS).doesNotBlockMovement().tickRandomly()
+            block = new BerryFruit(Block.Properties.create(Material.PLANTS, berryCrops.get(name)).doesNotBlockMovement().tickRandomly()
                     .hardnessAndResistance(0.0F).notSolid().sound(SoundType.CROP), index);
             block.setRegistryName(PokecubeCore.MODID, "fruit_" + name);
             BerryManager.berryFruits.put(index, block);
@@ -135,98 +137,106 @@ public class ItemGenerator
             final int index = ((ItemBerry) BerryManager.getBerryItem(name)).type.index;
 
             // Leaves
-            Block block = new BerryLeaf(Block.Properties.create(Material.LEAVES).hardnessAndResistance(0.2F)
+            Block block = new BerryLeaf(Block.Properties.create(Material.LEAVES, berryLeaves.get(name)).hardnessAndResistance(0.2F)
                     .tickRandomly().notSolid().sound(SoundType.PLANT), index);
             block.setRegistryName(PokecubeCore.MODID, "leaves_" + name);
             ItemGenerator.leaves.put(name, block);
             registry.register(block);
 
             // Logs
-            block = Blocks.createLogBlock(ItemGenerator.berryWoods.get(name), MaterialColor.WOOD);
+            block = Blocks.createLogBlock(berryWoods.get(name), berryWoods.get(name));
             block.setRegistryName(PokecubeCore.MODID, "log_" + name);
             ItemGenerator.logs.put(name, block);
             registry.register(block);
 
             // Woods
-            block = Blocks.createLogBlock(ItemGenerator.berryWoods.get(name), MaterialColor.WOOD);
+            block = Blocks.createLogBlock(berryWoods.get(name), berryWoods.get(name));
             block.setRegistryName(PokecubeCore.MODID, name + "_wood");
             ItemGenerator.woods.put(name, block);
             registry.register(block);
 
             // Stripped Logs
-            block = Blocks.createLogBlock(ItemGenerator.berryWoods.get(name), MaterialColor.WOOD);
+            block = Blocks.createLogBlock(berryWoods.get(name), berryWoods.get(name));
             block.setRegistryName(PokecubeCore.MODID, "stripped_" + name + "_log");
             ItemGenerator.stripped_logs.put(name, block);
             registry.register(block);
 
             // Stripped Woods
-            block = Blocks.createLogBlock(ItemGenerator.berryWoods.get(name), MaterialColor.WOOD);
+            block = Blocks.createLogBlock(berryWoods.get(name), berryWoods.get(name));
             block.setRegistryName(PokecubeCore.MODID, "stripped_" + name + "_wood");
             ItemGenerator.stripped_woods.put(name, block);
             registry.register(block);
 
             // Planks
-            block = new RotatedPillarBlock(Block.Properties.create(Material.WOOD, MaterialColor.WOOD)
+            block = new RotatedPillarBlock(Block.Properties.create(Material.WOOD, berryWoods.get(name))
                     .hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, "plank_" + name);
             ItemGenerator.planks.put(name, block);
             registry.register(block);
 
             // Stairs
-            block = new GenericWoodStairs(Blocks.OAK_PLANKS.getDefaultState(), Block.Properties.from(
-                    Blocks.OAK_STAIRS));
+            block = new GenericWoodStairs(Blocks.OAK_PLANKS.getDefaultState(), Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_stairs");
             ItemGenerator.stairs.put(name, block);
             registry.register(block);
 
             // Slabs
-            block = new SlabBlock(Block.Properties.from(Blocks.OAK_SLAB));
+            block = new SlabBlock(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_slab");
             ItemGenerator.slabs.put(name, block);
             registry.register(block);
 
             // Fences
-            block = new FenceBlock(Block.Properties.from(Blocks.OAK_FENCE));
+            block = new FenceBlock(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_fence");
             ItemGenerator.fences.put(name, block);
             registry.register(block);
 
             // Fence Gates
-            block = new FenceGateBlock(Block.Properties.from(Blocks.OAK_FENCE_GATE));
+            block = new FenceGateBlock(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_fence_gate");
             ItemGenerator.fence_gates.put(name, block);
             registry.register(block);
 
             // Pressure Plates
-            block = new GenericPressurePlate(Sensitivity.EVERYTHING, Block.Properties.from(Blocks.OAK_PRESSURE_PLATE));
+            block = new GenericPressurePlate(Sensitivity.EVERYTHING, Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_pressure_plate");
             ItemGenerator.pressure_plates.put(name, block);
             registry.register(block);
 
             // Buttons
-            block = new GenericWoodButton(Block.Properties.from(Blocks.OAK_BUTTON));
+            block = new GenericWoodButton(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD));
             block.setRegistryName(PokecubeCore.MODID, name + "_button");
             ItemGenerator.buttons.put(name, block);
             registry.register(block);
 
             // Trapdoors
-            block = new GenericTrapDoor(Block.Properties.from(Blocks.OAK_TRAPDOOR).notSolid());
+            block = new GenericTrapDoor(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD).notSolid());
             block.setRegistryName(PokecubeCore.MODID, name + "_trapdoor");
             ItemGenerator.trapdoors.put(name, block);
             registry.register(block);
 
             // Doors
-            block = new GenericDoor(Block.Properties.from(Blocks.OAK_DOOR).notSolid());
+            block = new GenericDoor(Block.Properties.create(
+            		Material.WOOD, berryWoods.get(name)).hardnessAndResistance(2.0F).sound(SoundType.WOOD).notSolid());
             block.setRegistryName(PokecubeCore.MODID, name + "_door");
             ItemGenerator.doors.put(name, block);
             registry.register(block);
         }
 
-        for (final String name : ItemGenerator.onlyBerryLeaves)
+        final List<String> leaves = Lists.newArrayList(ItemGenerator.onlyBerryLeaves.keySet());
+        for (final String name : leaves)
         {
             final int index = ((ItemBerry) BerryManager.getBerryItem(name)).type.index;
             // Leaves
-            final Block block = new BerryLeaf(Block.Properties.create(Material.LEAVES).hardnessAndResistance(0.2F)
+            final Block block = new BerryLeaf(Block.Properties.create(Material.LEAVES, onlyBerryLeaves.get(name)).hardnessAndResistance(0.2F)
                     .tickRandomly().notSolid().sound(SoundType.PLANT), index);
             block.setRegistryName(PokecubeCore.MODID, "leaves_" + name);
             ItemGenerator.leaves.put(name, block);
@@ -293,6 +303,7 @@ public class ItemGenerator
     public static void makeWoodItems(final IForgeRegistry<Item> registry)
     {
         final List<String> names = Lists.newArrayList(ItemGenerator.berryWoods.keySet());
+        final List<String> leaves = Lists.newArrayList(ItemGenerator.onlyBerryLeaves.keySet());
         Collections.sort(names);
         for (final String name : names)
         {
@@ -330,7 +341,7 @@ public class ItemGenerator
             registry.register(new BlockItem(ItemGenerator.doors.get(name), new Item.Properties().group(
                     PokecubeItems.POKECUBEBERRIES)).setRegistryName(ItemGenerator.doors.get(name).getRegistryName()));
         }
-        for (final String name : ItemGenerator.onlyBerryLeaves)
+        for (final String name : leaves)
             registry.register(new BlockItem(ItemGenerator.leaves.get(name), new Item.Properties().group(
                     PokecubeItems.POKECUBEBERRIES)).setRegistryName(ItemGenerator.leaves.get(name).getRegistryName()));
     }

--- a/src/main/java/pokecube/legends/blocks/BlockBase.java
+++ b/src/main/java/pokecube/legends/blocks/BlockBase.java
@@ -6,6 +6,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
@@ -27,21 +28,21 @@ public class BlockBase extends Block
     String     infoname;
     boolean    hasTextInfo = true;
 
-    public BlockBase(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest)
+    public BlockBase(final String name, final Material material, final MaterialColor color, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest)
     {
-        this(name, material, hardnessresistance, hardnessresistance, sound, tool, harvest);
+        this(name, material, color, hardnessresistance, hardnessresistance, sound, tool, harvest);
         this.setInfoBlockName(name);
     }
 
-    public BlockBase(final String name, final Material material, final float hardness, final float resistance,
+    public BlockBase(final String name, final Material material, final MaterialColor color, final float hardness, final float resistance,
             final SoundType sound, final ToolType tool, final int harvestLevel)
     {
-        super(Block.Properties.create(material).hardnessAndResistance(hardness, resistance).sound(sound).harvestLevel(harvestLevel));
+        super(Block.Properties.create(material, color).hardnessAndResistance(hardness, resistance).sound(sound).harvestLevel(harvestLevel));
     }
 
-    public BlockBase(final String name, final Material material, final ToolType tool, final int level)
+    public BlockBase(final String name, final Material material, final MaterialColor color, final ToolType tool, final int level)
     {
-        super(Block.Properties.create(material).harvestTool(tool).harvestLevel(level));
+        super(Block.Properties.create(material, color).harvestTool(tool).harvestLevel(level));
     }
 
     public BlockBase(final String name, final Properties props)

--- a/src/main/java/pokecube/legends/blocks/PlantBase.java
+++ b/src/main/java/pokecube/legends/blocks/PlantBase.java
@@ -8,6 +8,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.FlowerBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.loot.LootContext;
@@ -21,9 +22,9 @@ public class PlantBase extends FlowerBlock
 {
     public static final Block block = null;
 
-    public PlantBase(final Material material, final float hardness, final float resistance, final SoundType sound)
+    public PlantBase(final Material material, MaterialColor color, final float hardness, final float resistance, final SoundType sound)
     {
-        super(Effects.SATURATION, 0, Block.Properties.create(material).hardnessAndResistance(hardness, resistance)
+        super(Effects.SATURATION, 0, Block.Properties.create(material, color).hardnessAndResistance(hardness, resistance)
                 .doesNotBlockMovement().sound(sound));
     }
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/LegendaryBlock.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/LegendaryBlock.java
@@ -2,12 +2,13 @@ package pokecube.legends.blocks.customblocks;
 
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import pokecube.legends.blocks.BlockBase;
 
 public class LegendaryBlock extends BlockBase
 {
-    public LegendaryBlock(final String name, final Material material)
+    public LegendaryBlock(final String name, final Material material, MaterialColor color)
     {
-        super(name, Properties.create(material).sound(SoundType.METAL).hardnessAndResistance(2000, 2000));
+        super(name, Properties.create(material, color).sound(SoundType.METAL).hardnessAndResistance(2000, 2000));
     }
 }

--- a/src/main/java/pokecube/legends/blocks/customblocks/NatureCoreBlock.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/NatureCoreBlock.java
@@ -11,6 +11,7 @@ import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluids;
@@ -81,10 +82,10 @@ public class NatureCoreBlock extends Rotates implements IWaterLoggable
     }
 
     // Default States
-    public NatureCoreBlock(final String name, final Material material, final float hardness, final float resistance,
+    public NatureCoreBlock(final String name, final Material material, final MaterialColor color, final float hardness, final float resistance,
             final SoundType sound, final ToolType tool, final int harvest)
     {
-        super(name, material, hardness, resistance, sound, tool, harvest);
+        super(name, material, color, hardness, resistance, sound, tool, harvest);
         this.setDefaultState(this.stateContainer.getBaseState().with(NatureCoreBlock.HALF, NatureCorePart.BOTTOM).with(
                 NatureCoreBlock.FACING, Direction.NORTH).with(NatureCoreBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/legends/blocks/customblocks/RaidSpawnBlock.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/RaidSpawnBlock.java
@@ -7,6 +7,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.client.util.ITooltipFlag;
@@ -64,9 +65,9 @@ public class RaidSpawnBlock extends MaxBlock
     String  infoname;
     boolean hasTextInfo = true;
 
-    public RaidSpawnBlock(final Material material)
+    public RaidSpawnBlock(final Material material, MaterialColor color)
     {
-        super(Properties.create(material).sound(SoundType.METAL).tickRandomly().hardnessAndResistance(2000, 2000));
+        super(Properties.create(material).sound(SoundType.METAL).tickRandomly().hardnessAndResistance(2000, 2000), color);
         this.setDefaultState(this.stateContainer.getBaseState().with(RaidSpawnBlock.ACTIVE, State.EMPTY));
     }
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Regice_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Regice_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -18,8 +19,9 @@ public class Regice_Core extends BlockBase {
 
 	public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-	public Regice_Core(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
-		super(name, material, hardnessresistance, sound, tool, harvest);
+	public Regice_Core(final String name, final Material material, final MaterialColor color, 
+			final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
+		super(name, material, color, hardnessresistance, sound, tool, harvest);
 		this.setDefaultState(this.stateContainer.getBaseState().with(Regice_Core.FACING, Direction.NORTH));
 	}
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Regidrago_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Regidrago_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -18,8 +19,9 @@ public class Regidrago_Core extends BlockBase {
 
 	public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-	public Regidrago_Core(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
-		super(name, material, hardnessresistance, sound, tool, harvest);
+	public Regidrago_Core(final String name, final Material material, final MaterialColor color, 
+			final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
+		super(name, material, color, hardnessresistance, sound, tool, harvest);
 		this.setDefaultState(this.stateContainer.getBaseState().with(Regidrago_Core.FACING, Direction.NORTH));
 	}
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Regieleki_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Regieleki_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -18,8 +19,9 @@ public class Regieleki_Core extends BlockBase {
 
 	public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-	public Regieleki_Core(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
-		super(name, material, hardnessresistance, sound, tool, harvest);
+	public Regieleki_Core(final String name, final Material material, final MaterialColor color, 
+			final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
+		super(name, material, color, hardnessresistance, sound, tool, harvest);
 		this.setDefaultState(this.stateContainer.getBaseState().with(Regieleki_Core.FACING, Direction.NORTH));
 	}
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Regigigas_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Regigigas_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -18,8 +19,9 @@ public class Regigigas_Core extends BlockBase {
 
 	public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-	public Regigigas_Core(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
-		super(name, material, hardnessresistance, sound, tool, harvest);
+	public Regigigas_Core(final String name, final Material material, final MaterialColor color, 
+			final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
+		super(name, material, color, hardnessresistance, sound, tool, harvest);
 		this.setDefaultState(this.stateContainer.getBaseState().with(Regigigas_Core.FACING, Direction.NORTH));
 	}
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Regirock_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Regirock_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -18,8 +19,9 @@ public class Regirock_Core extends BlockBase {
 
 	public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-	public Regirock_Core(final String name, final Material material, final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
-		super(name, material, hardnessresistance, sound, tool, harvest);
+	public Regirock_Core(final String name, final Material material, final MaterialColor color, 
+			final float hardnessresistance, final SoundType sound, final ToolType tool, final int harvest) {
+		super(name, material, color, hardnessresistance, sound, tool, harvest);
 		this.setDefaultState(this.stateContainer.getBaseState().with(Regirock_Core.FACING, Direction.NORTH));
 	}
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Registeel_Core.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Registeel_Core.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
@@ -19,10 +20,10 @@ public class Registeel_Core extends BlockBase
 
     public static final DirectionProperty FACING = HorizontalBlock.HORIZONTAL_FACING;
 
-    public Registeel_Core(final String name, final Material material, final float hardnessresistance,
+    public Registeel_Core(final String name, final Material material, final MaterialColor color, final float hardnessresistance,
             final SoundType sound, final ToolType tool, final int harvest)
     {
-        super(name, material, hardnessresistance, sound, tool, harvest);
+        super(name, material, color, hardnessresistance, sound, tool, harvest);
         this.setDefaultState(this.stateContainer.getBaseState().with(Registeel_Core.FACING, Direction.NORTH));
     }
 

--- a/src/main/java/pokecube/legends/blocks/customblocks/Rotates.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/Rotates.java
@@ -5,6 +5,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.item.BlockItemUseContext;
@@ -24,17 +25,17 @@ public class Rotates extends BlockBase
     private static final BooleanProperty   WATERLOGGED = BlockStateProperties.WATERLOGGED;
     private static final DirectionProperty FACING      = HorizontalBlock.HORIZONTAL_FACING;
 
-    public Rotates(final String name, final Material material, final float hardness, final float resistance,
+    public Rotates(final String name, final Material material, final MaterialColor color, final float hardness, final float resistance,
             final SoundType sound, final ToolType tool, final int harvest)
     {
-    	super(name, material, hardness, resistance, sound, tool, harvest);
+    	super(name, material, color, hardness, resistance, sound, tool, harvest);
         this.setDefaultState(this.stateContainer.getBaseState().with(Rotates.FACING, Direction.NORTH).with(
                 Rotates.WATERLOGGED, false));
     }
 
-    public Rotates(final String name, final Material material, final ToolType tool, final int level)
+    public Rotates(final String name, final Material material, final MaterialColor color, final ToolType tool, final int level)
     {
-        super(name, material, tool, level);
+        super(name, material, color, tool, level);
         this.setDefaultState(this.stateContainer.getBaseState().with(Rotates.FACING, Direction.NORTH).with(
                 Rotates.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/legends/blocks/customblocks/SpaceCoreBlock.java
+++ b/src/main/java/pokecube/legends/blocks/customblocks/SpaceCoreBlock.java
@@ -13,6 +13,7 @@ import net.minecraft.block.HorizontalBlock;
 import net.minecraft.block.IWaterLoggable;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.fluid.Fluids;
@@ -170,10 +171,10 @@ public class SpaceCoreBlock extends Rotates implements IWaterLoggable
     }
 
     // Default States
-    public SpaceCoreBlock(final String name, final Material material, final float hardness, final float resistance,
+    public SpaceCoreBlock(final String name, final Material material, final MaterialColor color, final float hardness, final float resistance,
             final SoundType sound, final ToolType tool, final int harvest)
     {
-        super(name, material, hardness, resistance, sound, tool, harvest);
+        super(name, material, color, hardness, resistance, sound, tool, harvest);
         this.setDefaultState(this.stateContainer.getBaseState().with(SpaceCoreBlock.HALF, TimeSpaceCorePart.BOTTOM)
                 .with(SpaceCoreBlock.FACING, Direction.NORTH).with(SpaceCoreBlock.WATERLOGGED, false));
     }

--- a/src/main/java/pokecube/legends/blocks/normalblocks/DarkStoneBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/DarkStoneBlock.java
@@ -2,6 +2,7 @@ package pokecube.legends.blocks.normalblocks;
 
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,7 +18,7 @@ import pokecube.legends.init.ItemInit;
 
 public class DarkStoneBlock extends BlockBase
 {
-    public DarkStoneBlock(final String name, final Material material)
+    public DarkStoneBlock(final String name, final Material material, MaterialColor color)
     {
         super(name, Properties.create(material).sound(SoundType.STONE).hardnessAndResistance(3, 8).harvestTool(
                 ToolType.PICKAXE).harvestLevel(1));

--- a/src/main/java/pokecube/legends/blocks/normalblocks/GrassAgedBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/GrassAgedBlock.java
@@ -3,6 +3,7 @@ package pokecube.legends.blocks.normalblocks;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,9 +22,9 @@ import pokecube.legends.init.ItemInit;
 
 public class GrassAgedBlock extends BlockBase
 {
-    public GrassAgedBlock(final String name, final Material material)
+    public GrassAgedBlock(final String name, final Material material, MaterialColor color)
     {
-        super(name, Properties.create(material).sound(SoundType.PLANT).hardnessAndResistance(1, 2).harvestTool(
+        super(name, Properties.create(material, color).sound(SoundType.PLANT).hardnessAndResistance(1, 2).harvestTool(
                 ToolType.SHOVEL).harvestLevel(1));
     }
 

--- a/src/main/java/pokecube/legends/blocks/normalblocks/GrassJungleBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/GrassJungleBlock.java
@@ -3,6 +3,7 @@ package pokecube.legends.blocks.normalblocks;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,7 +22,7 @@ import pokecube.legends.init.ItemInit;
 
 public class GrassJungleBlock extends BlockBase
 {
-    public GrassJungleBlock(final String name, final Material material)
+    public GrassJungleBlock(final String name, final Material material, MaterialColor color)
     {
         super(name, Properties.create(material).sound(SoundType.PLANT).hardnessAndResistance(1, 2).harvestTool(
                 ToolType.SHOVEL).harvestLevel(1));

--- a/src/main/java/pokecube/legends/blocks/normalblocks/GrassMussBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/GrassMussBlock.java
@@ -3,6 +3,7 @@ package pokecube.legends.blocks.normalblocks;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,7 +22,7 @@ import pokecube.legends.init.ItemInit;
 
 public class GrassMussBlock extends BlockBase
 {
-    public GrassMussBlock(final String name, final Material material)
+    public GrassMussBlock(final String name, final Material material, MaterialColor color)
     {
         super(name, Properties.create(material).sound(SoundType.PLANT).hardnessAndResistance(1, 2).harvestTool(
                 ToolType.SHOVEL).harvestLevel(1));

--- a/src/main/java/pokecube/legends/blocks/normalblocks/MagneticBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/MagneticBlock.java
@@ -3,6 +3,7 @@ package pokecube.legends.blocks.normalblocks;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.ServerPlayerEntity;
@@ -19,7 +20,7 @@ import pokecube.legends.blocks.BlockBase;
 
 public class MagneticBlock extends BlockBase
 {
-    public MagneticBlock(final String name, final Material material)
+    public MagneticBlock(final String name, final Material material, MaterialColor color)
     {
         super(name, Properties.create(material).sound(SoundType.STONE).hardnessAndResistance(3, 8).harvestTool(
                 ToolType.PICKAXE).harvestLevel(1));

--- a/src/main/java/pokecube/legends/blocks/normalblocks/SandDistorBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/SandDistorBlock.java
@@ -3,6 +3,7 @@ package pokecube.legends.blocks.normalblocks;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -21,9 +22,9 @@ import pokecube.legends.init.ItemInit;
 
 public class SandDistorBlock extends BlockBase
 {
-    public SandDistorBlock(final String name, final Material material)
+    public SandDistorBlock(final String name, final Material material, MaterialColor color)
     {
-        super(name, Properties.create(material).sound(SoundType.SCAFFOLDING).hardnessAndResistance(4, 5).harvestTool(
+        super(name, Properties.create(material, color).sound(SoundType.SCAFFOLDING).hardnessAndResistance(4, 5).harvestTool(
                 ToolType.SHOVEL).harvestLevel(2));
     }
     

--- a/src/main/java/pokecube/legends/blocks/normalblocks/SandUltraBlock.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/SandUltraBlock.java
@@ -2,6 +2,7 @@ package pokecube.legends.blocks.normalblocks;
 
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
@@ -17,9 +18,9 @@ import pokecube.legends.init.ItemInit;
 
 public class SandUltraBlock extends BlockBase
 {
-    public SandUltraBlock(final String name, final Material material)
+    public SandUltraBlock(final String name, final Material material, MaterialColor color)
     {
-        super(name, Properties.create(material).sound(SoundType.SNOW).hardnessAndResistance(2, 6).harvestTool(
+        super(name, Properties.create(material, color).sound(SoundType.SAND).hardnessAndResistance(2, 6).harvestTool(
                 ToolType.SHOVEL).harvestLevel(1));
     }
 

--- a/src/main/java/pokecube/legends/blocks/normalblocks/UltraTorch1.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/UltraTorch1.java
@@ -14,7 +14,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 public class UltraTorch1 extends TorchBlock
 {	
     public UltraTorch1() {
-    	super(Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0.0f), 
+    	super(Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0.0f).doesNotBlockMovement(), 
     			ParticleTypes.CAMPFIRE_COSY_SMOKE);
 	}
     
@@ -24,6 +24,6 @@ public class UltraTorch1 extends TorchBlock
         double d0 = (double)pos.getX() + 0.5D;
         double d1 = (double)pos.getY() + 0.7D;
         double d2 = (double)pos.getZ() + 0.5D;
-        worldIn.addParticle(ParticleTypes.DRAGON_BREATH, d0, d1, d2, 0.0D, 0.2D, 0.0D);
+        worldIn.addParticle(ParticleTypes.DRAGON_BREATH, d0 + 0.27D, d1 + 0.22D, d2 + 0.27D, 0.0D, 0.0D, 0.0D);
     }
 }

--- a/src/main/java/pokecube/legends/blocks/normalblocks/UltraTorch1Wall.java
+++ b/src/main/java/pokecube/legends/blocks/normalblocks/UltraTorch1Wall.java
@@ -15,7 +15,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 public class UltraTorch1Wall extends WallTorchBlock
 {	
     public UltraTorch1Wall() {
-    	super(Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0.0f),
+    	super(Properties.create(Material.MISCELLANEOUS).hardnessAndResistance(0.0f).doesNotBlockMovement(),
     			ParticleTypes.CAMPFIRE_COSY_SMOKE);
 	}
     

--- a/src/main/java/pokecube/legends/init/BlockInit.java
+++ b/src/main/java/pokecube/legends/init/BlockInit.java
@@ -202,78 +202,78 @@ public class BlockInit
     static
     {
         // Block Raid
-        RAID_SPAWN = PokecubeLegends.BLOCKS.register("raidspawn_block", () -> new RaidSpawnBlock(Material.IRON)
+        RAID_SPAWN = PokecubeLegends.BLOCKS.register("raidspawn_block", () -> new RaidSpawnBlock(Material.IRON, MaterialColor.BLACK)
                 .setInfoBlockName("raidspawn"));
 
         // Decorative_Blocks
         DYNA_LEAVE1 = PokecubeLegends.BLOCKS.register("dyna_leave_1", () -> new LeavesBlock(Block.Properties.create(
-                Material.LEAVES).hardnessAndResistance(1f, 5).sound(SoundType.WET_GRASS).noDrops().notSolid()));
+                Material.LEAVES, MaterialColor.PINK).hardnessAndResistance(1f, 5).sound(SoundType.WET_GRASS).noDrops().notSolid()));
         DYNA_LEAVE2 = PokecubeLegends.BLOCKS.register("dyna_leave_2", () -> new LeavesBlock(Block.Properties.create(
-                Material.LEAVES).hardnessAndResistance(1f, 5).sound(SoundType.WET_GRASS).noDrops().notSolid()));
+                Material.LEAVES, MaterialColor.PINK).hardnessAndResistance(1f, 5).sound(SoundType.WET_GRASS).noDrops().notSolid()));
 
         OCEAN_BRICK = PokecubeLegends.BLOCKS.register("oceanbrick", () -> new Block(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
-        SKY_BRICK   = PokecubeLegends.BLOCKS.register("skybrick", () -> new Block(Block.Properties.create(Material.ROCK)
+                Material.ROCK, MaterialColor.CYAN).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
+        SKY_BRICK   = PokecubeLegends.BLOCKS.register("skybrick", () -> new Block(Block.Properties.create(Material.ROCK, MaterialColor.BLUE)
                 .hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
         SPATIAN_BRICK = PokecubeLegends.BLOCKS.register("spatianbrick", () -> new Block(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
+                Material.ROCK, MaterialColor.MAGENTA).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
         MAGMA_BRICK   = PokecubeLegends.BLOCKS.register("magmabrick", () -> new MagmaBlock(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(1.5f, 10).sound(SoundType.NETHERRACK).setLightLevel(b -> 3)
+                Material.ROCK, MaterialColor.NETHERRACK).hardnessAndResistance(1.5f, 10).sound(SoundType.NETHERRACK).setLightLevel(b -> 3)
         			.setEmmisiveRendering((s, r, p) -> true)));
         DARKSKY_BRICK = PokecubeLegends.BLOCKS.register("darkskybrick", () -> new Block(Block.Properties.create(
-                Material.ROCK).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
+                Material.ROCK, MaterialColor.LIGHT_GRAY).hardnessAndResistance(1.5f, 10).sound(SoundType.STONE)));
 
         METEOR_BLOCK = PokecubeLegends.BLOCKS_TAB.register("meteor_block", () -> new FallingBlock(Block.Properties
-                .create(Material.GOURD).hardnessAndResistance(2.5f).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)
+                .create(Material.GOURD, MaterialColor.BLUE_TERRACOTTA).hardnessAndResistance(2.5f).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)
                 .harvestLevel(2)));
 
         CRYSTAL_BRICK = PokecubeLegends.BLOCKS_TAB.register("crystalbrick", () -> new BlockBase("crystalbrick",
-                Material.PACKED_ICE, 0.5F, SoundType.GLASS, ToolType.PICKAXE, 1).noInfoBlock());
+                Material.PACKED_ICE, MaterialColor.LIGHT_BLUE, 0.5F, SoundType.GLASS, ToolType.PICKAXE, 1).noInfoBlock());
 
         // Dimensions
         SPECTRUM_GLASS = PokecubeLegends.BLOCKS_TAB.register("spectrum_glass", () -> new SpectrumGlass("spectrum_glass",
                 Block.Properties.from(Blocks.GLASS).notSolid()));
         ULTRA_DIRTAGED = PokecubeLegends.BLOCKS_TAB.register("ultradirt3", () -> new BlockBase("ultradirt3",
-                Material.ORGANIC, 0.5f, SoundType.WET_GRASS, ToolType.SHOVEL, 1).noInfoBlock());
+                Material.ORGANIC, MaterialColor.YELLOW_TERRACOTTA, 0.5f, SoundType.WET_GRASS, ToolType.SHOVEL, 1).noInfoBlock());
         ULTRA_ROCKDISTOR = PokecubeLegends.BLOCKS_TAB.register("ultradirt4", () -> new BlockBase("ultradirt4",
-                Material.ROCK, 0.9f, SoundType.METAL, ToolType.PICKAXE, 1).noInfoBlock());
+                Material.ROCK, MaterialColor.PURPLE_TERRACOTTA, 0.9f, SoundType.METAL, ToolType.PICKAXE, 1).noInfoBlock());
         ULTRA_MAGNETIC = PokecubeLegends.BLOCKS_TAB.register("ultramagnetic", () -> new MagneticBlock("ultramagnetic",
-                Material.GLASS).noInfoBlock());
+                Material.ROCK, MaterialColor.BLUE).noInfoBlock());
         ULTRA_SANDSTONE = PokecubeLegends.BLOCKS_TAB.register("ultrasandstone", () -> new BlockBase("ultrasandstone",
-                Material.SAND, 0.5f, SoundType.STONE, ToolType.PICKAXE, 1).noInfoBlock());
+                Material.ROCK, MaterialColor.SNOW, 0.5f, SoundType.STONE, ToolType.PICKAXE, 1).noInfoBlock());
         ULTRA_DARKSTONE = PokecubeLegends.BLOCKS_TAB.register("ultracobbles", () -> new DarkStoneBlock("ultracobbles",
-                Material.ROCK).noInfoBlock());
+                Material.ROCK, MaterialColor.BLACK).noInfoBlock());
         ULTRA_DARKCOBBLES = PokecubeLegends.BLOCKS_TAB.register("ultrarock", () -> new BlockBase("ultrarock",
-                Material.ROCK, 0.8f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.ROCK, MaterialColor.BLACK, 0.8f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         ULTRA_GRASSMUSS = PokecubeLegends.BLOCKS_TAB.register("ultragrass1", () -> new GrassMussBlock("ultragrass1",
-                Material.ORGANIC).noInfoBlock());
+                Material.ORGANIC, MaterialColor.RED).noInfoBlock());
         ULTRA_DIRTMUSS = PokecubeLegends.BLOCKS_TAB.register("ultradirt1", () -> new BlockBase("ultradirt1",
-                Material.CLAY, 0.5f, SoundType.GROUND, ToolType.SHOVEL, 1).noInfoBlock());
+                Material.CLAY, MaterialColor.PURPLE, 0.5f, SoundType.GROUND, ToolType.SHOVEL, 1).noInfoBlock());
         ULTRA_GRASSJUN = PokecubeLegends.BLOCKS_TAB.register("ultragrass2", () -> new GrassJungleBlock("ultragrass2",
-                Material.ORGANIC).noInfoBlock());
+                Material.ORGANIC, MaterialColor.CYAN).noInfoBlock());
         ULTRA_DIRTJUN = PokecubeLegends.BLOCKS_TAB.register("ultradirt2", () -> new BlockBase("ultradirt2",
-                Material.GOURD, 0.5f, SoundType.GROUND, ToolType.SHOVEL, 1).noInfoBlock());
-        ULTRA_STONE = PokecubeLegends.BLOCKS_TAB.register("ultrastone", () -> new BlockBase("ultrastone", Material.ROCK,
-                1.5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
-        ULTRA_METAL = PokecubeLegends.BLOCKS_TAB.register("ultrablock", () -> new BlockBase("ultrablock", Material.IRON,
-                5.0f, 10f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.GOURD, MaterialColor.YELLOW_TERRACOTTA, 0.5f, SoundType.GROUND, ToolType.SHOVEL, 1).noInfoBlock());
+        ULTRA_STONE = PokecubeLegends.BLOCKS_TAB.register("ultrastone", () -> new BlockBase("ultrastone", Material.ROCK, 
+        		MaterialColor.CYAN_TERRACOTTA, 1.5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+        ULTRA_METAL = PokecubeLegends.BLOCKS_TAB.register("ultrablock", () -> new BlockBase("ultrablock", Material.IRON, 
+        		MaterialColor.LIME, 5.0f, 10f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         ULTRA_SAND = PokecubeLegends.BLOCKS_TAB.register("ultrasand", () -> new SandUltraBlock("ultrasand",
-                Material.SAND).noInfoBlock());
+                Material.SAND, MaterialColor.SNOW).noInfoBlock());
         ULTRA_SANDDISTOR = PokecubeLegends.BLOCKS_TAB.register("ultrasand1", () -> new SandDistorBlock("ultrasand1",
-                Material.CLAY).noInfoBlock());
+                Material.CLAY, MaterialColor.PURPLE).noInfoBlock());
         ULTRA_GRASSAGED = PokecubeLegends.BLOCKS_TAB.register("ultragrass3", () -> new GrassAgedBlock("ultragrass3",
-                Material.GOURD).noInfoBlock());
+                Material.GOURD, MaterialColor.YELLOW).noInfoBlock());
         TEMPORAL_CRYSTAL = PokecubeLegends.BLOCKS_TAB.register("temporal_crystal", () -> new BlockBase(
-                "temporal_crystal", Material.GLASS, 1.5f, SoundType.GLASS, ToolType.PICKAXE, 1).noInfoBlock());
+                "temporal_crystal", Material.GLASS, MaterialColor.LIGHT_BLUE, 1.5f, SoundType.GLASS, ToolType.PICKAXE, 1).noInfoBlock());
 
         // Distortic World
         DISTORTIC_GRASS = PokecubeLegends.BLOCKS_TAB.register("distortic_grass", () -> new GrassDistorticBlock(
-                BlockBase.Properties.create(Material.ORGANIC).sound(SoundType.NETHER_WART).hardnessAndResistance(1, 2)
+                BlockBase.Properties.create(Material.ORGANIC, MaterialColor.PINK_TERRACOTTA).sound(SoundType.NETHER_WART).hardnessAndResistance(1, 2)
                         .harvestTool(ToolType.SHOVEL).harvestLevel(1)));
         DISTORTIC_STONE = PokecubeLegends.BLOCKS_TAB.register("distortic_stone", () -> new BlockBase("distortic_stone",
-                Material.ROCK, 1.5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.ROCK, MaterialColor.BLACK_TERRACOTTA, 1.5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         DISTORTIC_MIRROR = PokecubeLegends.BLOCKS_TAB.register("distortic_mirror", () -> new BlockBase(
-                "distortic_mirror", Material.GLASS, 2.5f, SoundType.GLASS, ToolType.PICKAXE, 2).noInfoBlock());
+                "distortic_mirror", Material.GLASS, MaterialColor.CLAY, 2.5f, SoundType.GLASS, ToolType.PICKAXE, 2).noInfoBlock());
 
         // Torches
         ULTRA_TORCH1 = PokecubeLegends.BLOCKS_TAB.register("ultra_torch1", () -> new UltraTorch1());
@@ -281,52 +281,56 @@ public class BlockInit
 
         // Plants
         ULTRA_SAPLING_UB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_sapling01", () -> new SaplingBase(
-                () -> new Ultra_Tree01(), Block.Properties.from(Blocks.OAK_SAPLING)));
+                () -> new Ultra_Tree01(), Block.Properties.create(Material.PLANTS, MaterialColor.BLUE)
+                .hardnessAndResistance(0f, 1f).sound(SoundType.PLANT).doesNotBlockMovement().notSolid()));
         ULTRA_SAPLING_UB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_sapling02", () -> new SaplingBase(
-                () -> new Ultra_Tree02(), Block.Properties.from(Blocks.OAK_SAPLING)));
+                () -> new Ultra_Tree02(), Block.Properties.create(Material.PLANTS, MaterialColor.FOLIAGE)
+                .hardnessAndResistance(0f, 1f).sound(SoundType.PLANT).doesNotBlockMovement().notSolid()));
         ULTRA_SAPLING_UB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_sapling03", () -> new SaplingBase(
-                () -> new Ultra_Tree03(), Block.Properties.from(Blocks.OAK_SAPLING)));
+                () -> new Ultra_Tree03(), Block.Properties.create(Material.PLANTS, MaterialColor.YELLOW)
+                .hardnessAndResistance(0f, 1f).sound(SoundType.PLANT).doesNotBlockMovement().notSolid()));
         DISTORTIC_SAPLING = PokecubeLegends.BLOCKS_TAB.register("distortic_sapling", () -> new SaplingBase(
-                () -> new Distortic_Tree(), Block.Properties.from(Blocks.OAK_SAPLING)));
+                () -> new Distortic_Tree(), Block.Properties.create(Material.PLANTS, MaterialColor.PURPLE)
+                .hardnessAndResistance(0f, 1f).sound(SoundType.PLANT).doesNotBlockMovement().notSolid()));
 
         // Woods (LOGS/LEAVES/PLANKS)
-        ULTRA_LEAVEUB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave01", () -> new LeavesBlock(Block.Properties
-                .from(Blocks.OAK_LEAVES).notSolid()));
+        ULTRA_LEAVEUB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave01", () -> new LeavesBlock(Block.Properties.create(
+                Material.LEAVES, MaterialColor.LIGHT_BLUE).hardnessAndResistance(1f, 5).sound(SoundType.PLANT).notSolid()));
         ULTRA_LOGUB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_log01", () -> Blocks.createLogBlock(
-                MaterialColor.PURPLE, MaterialColor.BLUE_TERRACOTTA));
+                MaterialColor.LIGHT_BLUE_TERRACOTTA, MaterialColor.LIGHT_BLUE_TERRACOTTA));
         INVERTED_WOOD = PokecubeLegends.BLOCKS_TAB.register("inverted_wood", () -> Blocks.createLogBlock(
-                MaterialColor.PURPLE, MaterialColor.BLUE_TERRACOTTA));
+                MaterialColor.LIGHT_BLUE_TERRACOTTA, MaterialColor.LIGHT_BLUE_TERRACOTTA));
         STRIP_INVERTED_LOG = PokecubeLegends.BLOCKS_TAB.register("stripped_inverted_log", () -> Blocks.createLogBlock(
-                MaterialColor.BLUE_TERRACOTTA, MaterialColor.BLUE_TERRACOTTA));
+                MaterialColor.LIGHT_BLUE_TERRACOTTA, MaterialColor.LIGHT_BLUE_TERRACOTTA));
         STRIP_INVERTED_WOOD = PokecubeLegends.BLOCKS_TAB.register("stripped_inverted_wood", () -> Blocks.createLogBlock(
-                MaterialColor.BLUE_TERRACOTTA, MaterialColor.BLUE_TERRACOTTA));
-        ULTRA_PLANKUB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank01", () -> new Block(Block.Properties.from(
-                Blocks.OAK_PLANKS)));
+                MaterialColor.LIGHT_BLUE_TERRACOTTA, MaterialColor.LIGHT_BLUE_TERRACOTTA));
+        ULTRA_PLANKUB01 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank01", () -> new Block(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).hardnessAndResistance(2.0F, 3.0f).sound(SoundType.WOOD)));
         INVERTED_STAIRS = PokecubeLegends.BLOCKS_TAB.register("inverted_stairs",
-                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.from(
-                        Blocks.OAK_PLANKS).sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f)));
-        INVERTED_SLAB = PokecubeLegends.BLOCKS_TAB.register("inverted_slab", () -> new SlabBlock(Block.Properties.from(
-                Blocks.OAK_SLAB)));
-        INVERTED_FENCE = PokecubeLegends.BLOCKS_TAB.register("inverted_fence", () -> new FenceBlock(Block.Properties
-                .from(Blocks.OAK_FENCE)));
-        INVERTED_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("inverted_fence_gate", () -> new FenceGateBlock(
-                Block.Properties.from(Blocks.OAK_FENCE_GATE)));
+                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.create(
+                		Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).hardnessAndResistance(2.0F, 3.0f).sound(SoundType.WOOD)));
+        INVERTED_SLAB = PokecubeLegends.BLOCKS_TAB.register("inverted_slab", () -> new SlabBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).hardnessAndResistance(2.0F, 3.0f).sound(SoundType.WOOD)));
+        INVERTED_FENCE = PokecubeLegends.BLOCKS_TAB.register("inverted_fence", () -> new FenceBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).hardnessAndResistance(2.0F, 3.0f).sound(SoundType.WOOD)));
+        INVERTED_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("inverted_fence_gate", () -> new FenceGateBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).hardnessAndResistance(2.0F, 3.0f).sound(SoundType.WOOD)));
         INVERTED_PR_PLATE = PokecubeLegends.BLOCKS_TAB.register("inverted_pressure_plate",
                 () -> new ItemGenerator.GenericPressurePlate(PressurePlateBlock.Sensitivity.EVERYTHING, Block.Properties
-                        .create(Material.WOOD).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
+                        .create(Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
                                 0.5F)));
         INVERTED_BUTTON = PokecubeLegends.BLOCKS_TAB.register("inverted_button",
-                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD).sound(SoundType.WOOD)
+                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).sound(SoundType.WOOD)
                         .doesNotBlockMovement().hardnessAndResistance(0.5F)));
         INVERTED_TRAPDOOR = PokecubeLegends.BLOCKS_TAB.register("inverted_trapdoor",
-                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.WOOD)
+                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA)
                         .sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f).notSolid()));
         INVERTED_DOOR = PokecubeLegends.BLOCKS_TAB.register("inverted_door", () -> new ItemGenerator.GenericDoor(
-                Block.Properties.create(Material.WOOD, MaterialColor.WOOD).sound(SoundType.WOOD).hardnessAndResistance(
+                Block.Properties.create(Material.WOOD, MaterialColor.LIGHT_BLUE_TERRACOTTA).sound(SoundType.WOOD).hardnessAndResistance(
                         2.0f, 3.0f).notSolid()));
 
-        ULTRA_LEAVEUB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave02", () -> new LeavesBlock(Block.Properties
-                .from(Blocks.OAK_LEAVES).notSolid()));
+        ULTRA_LEAVEUB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave02", () -> new LeavesBlock(Block.Properties.create(
+                Material.LEAVES, MaterialColor.FOLIAGE).hardnessAndResistance(1f, 5).sound(SoundType.PLANT).notSolid()));
         ULTRA_LOGUB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_log02", () -> Blocks.createLogBlock(
                 MaterialColor.GREEN, MaterialColor.YELLOW));
         TEMPORAL_WOOD = PokecubeLegends.BLOCKS_TAB.register("temporal_wood", () -> Blocks.createLogBlock(
@@ -335,173 +339,173 @@ public class BlockInit
                 MaterialColor.LIME, MaterialColor.LIME));
         STRIP_TEMPORAL_WOOD = PokecubeLegends.BLOCKS_TAB.register("stripped_temporal_wood", () -> Blocks.createLogBlock(
                 MaterialColor.LIME, MaterialColor.LIME));
-        ULTRA_PLANKUB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank02", () -> new Block(Block.Properties.from(
-                Blocks.OAK_PLANKS)));
+        ULTRA_PLANKUB02 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank02", () -> new Block(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIME).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         TEMPORAL_STAIRS = PokecubeLegends.BLOCKS_TAB.register("temporal_stairs",
-                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.from(
-                        Blocks.OAK_PLANKS).sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f)));
-        TEMPORAL_SLAB = PokecubeLegends.BLOCKS_TAB.register("temporal_slab", () -> new SlabBlock(Block.Properties.from(
-                Blocks.OAK_SLAB)));
-        TEMPORAL_FENCE = PokecubeLegends.BLOCKS_TAB.register("temporal_fence", () -> new FenceBlock(Block.Properties
-                .from(Blocks.OAK_FENCE)));
-        TEMPORAL_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("temporal_fence_gate", () -> new FenceGateBlock(
-                Block.Properties.from(Blocks.OAK_FENCE_GATE)));
+                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.create(
+                		Material.WOOD, MaterialColor.LIME).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        TEMPORAL_SLAB = PokecubeLegends.BLOCKS_TAB.register("temporal_slab", () -> new SlabBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIME).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        TEMPORAL_FENCE = PokecubeLegends.BLOCKS_TAB.register("temporal_fence", () -> new FenceBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIME).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        TEMPORAL_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("temporal_fence_gate", () -> new FenceGateBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.LIME).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         TEMPORAL_PR_PLATE = PokecubeLegends.BLOCKS_TAB.register("temporal_pressure_plate",
                 () -> new ItemGenerator.GenericPressurePlate(PressurePlateBlock.Sensitivity.EVERYTHING, Block.Properties
-                        .create(Material.WOOD).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
+                        .create(Material.WOOD, MaterialColor.LIME).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
                                 0.5F)));
         TEMPORAL_BUTTON = PokecubeLegends.BLOCKS_TAB.register("temporal_button",
-                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD).sound(SoundType.WOOD)
+                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD, MaterialColor.LIME).sound(SoundType.WOOD)
                         .doesNotBlockMovement().hardnessAndResistance(0.5F)));
         TEMPORAL_TRAPDOOR = PokecubeLegends.BLOCKS_TAB.register("temporal_trapdoor",
-                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.WOOD)
+                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.LIME)
                         .sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f).notSolid()));
         TEMPORAL_DOOR = PokecubeLegends.BLOCKS_TAB.register("temporal_door", () -> new ItemGenerator.GenericDoor(
-                Block.Properties.create(Material.WOOD, MaterialColor.WOOD).sound(SoundType.WOOD).hardnessAndResistance(
+                Block.Properties.create(Material.WOOD, MaterialColor.LIME).sound(SoundType.WOOD).hardnessAndResistance(
                         2.0f, 3.0f).notSolid()));
 
-        ULTRA_LEAVEUB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave03", () -> new LeavesBlock(Block.Properties
-                .from(Blocks.OAK_LEAVES).notSolid()));
+        ULTRA_LEAVEUB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_leave03", () -> new LeavesBlock(Block.Properties.create(
+                Material.LEAVES, MaterialColor.YELLOW).hardnessAndResistance(1f, 5).sound(SoundType.PLANT).notSolid()));
         ULTRA_LOGUB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_log03", () -> Blocks.createLogBlock(
-                MaterialColor.GOLD, MaterialColor.BROWN));
-        AGED_WOOD = PokecubeLegends.BLOCKS_TAB.register("aged_wood", () -> Blocks.createLogBlock(MaterialColor.GOLD,
+                MaterialColor.BROWN, MaterialColor.BROWN));
+        AGED_WOOD = PokecubeLegends.BLOCKS_TAB.register("aged_wood", () -> Blocks.createLogBlock(MaterialColor.BROWN,
                 MaterialColor.BROWN));
         STRIP_AGED_LOG = PokecubeLegends.BLOCKS_TAB.register("stripped_aged_log", () -> Blocks.createLogBlock(
-                MaterialColor.GOLD, MaterialColor.BROWN));
+                MaterialColor.BROWN, MaterialColor.BROWN));
         STRIP_AGED_WOOD = PokecubeLegends.BLOCKS_TAB.register("stripped_aged_wood", () -> Blocks.createLogBlock(
-                MaterialColor.GOLD, MaterialColor.BROWN));
-        ULTRA_PLANKUB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank03", () -> new Block(Block.Properties.from(
-                Blocks.OAK_PLANKS)));
+                MaterialColor.BROWN, MaterialColor.BROWN));
+        ULTRA_PLANKUB03 = PokecubeLegends.BLOCKS_TAB.register("ultra_plank03", () -> new Block(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BROWN).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         AGED_STAIRS = PokecubeLegends.BLOCKS_TAB.register("aged_stairs", () -> new ItemGenerator.GenericWoodStairs(
-                Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.from(Blocks.OAK_PLANKS).sound(SoundType.WOOD)
-                        .hardnessAndResistance(2.0f, 3.0f)));
-        AGED_SLAB = PokecubeLegends.BLOCKS_TAB.register("aged_slab", () -> new SlabBlock(Block.Properties.from(
-                Blocks.OAK_SLAB)));
-        AGED_FENCE = PokecubeLegends.BLOCKS_TAB.register("aged_fence", () -> new FenceBlock(Block.Properties.from(
-                Blocks.OAK_FENCE)));
-        AGED_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("aged_fence_gate", () -> new FenceGateBlock(
-                Block.Properties.from(Blocks.OAK_FENCE_GATE)));
+                Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.create(
+                		Material.WOOD, MaterialColor.BROWN).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        AGED_SLAB = PokecubeLegends.BLOCKS_TAB.register("aged_slab", () -> new SlabBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BROWN).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        AGED_FENCE = PokecubeLegends.BLOCKS_TAB.register("aged_fence", () -> new FenceBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BROWN).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        AGED_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("aged_fence_gate", () -> new FenceGateBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BROWN).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         AGED_PR_PLATE = PokecubeLegends.BLOCKS_TAB.register("aged_pressure_plate",
                 () -> new ItemGenerator.GenericPressurePlate(PressurePlateBlock.Sensitivity.EVERYTHING, Block.Properties
-                        .create(Material.WOOD).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
+                        .create(Material.WOOD, MaterialColor.BROWN).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
                                 0.5F)));
         AGED_BUTTON = PokecubeLegends.BLOCKS_TAB.register("aged_button", () -> new ItemGenerator.GenericWoodButton(
-                Block.Properties.create(Material.WOOD).sound(SoundType.WOOD).doesNotBlockMovement()
+                Block.Properties.create(Material.WOOD, MaterialColor.BROWN).sound(SoundType.WOOD).doesNotBlockMovement()
                         .hardnessAndResistance(0.5F)));
         AGED_TRAPDOOR = PokecubeLegends.BLOCKS_TAB.register("aged_trapdoor", () -> new ItemGenerator.GenericTrapDoor(
-                Block.Properties.create(Material.WOOD, MaterialColor.WOOD).sound(SoundType.WOOD).hardnessAndResistance(
+                Block.Properties.create(Material.WOOD, MaterialColor.BROWN).sound(SoundType.WOOD).hardnessAndResistance(
                         2.0f, 3.0f).notSolid()));
         AGED_DOOR = PokecubeLegends.BLOCKS_TAB.register("aged_door", () -> new ItemGenerator.GenericDoor(
-                Block.Properties.create(Material.WOOD, MaterialColor.WOOD).sound(SoundType.WOOD).hardnessAndResistance(
+                Block.Properties.create(Material.WOOD, MaterialColor.BROWN).sound(SoundType.WOOD).hardnessAndResistance(
                         2.0f, 3.0f).notSolid()));
 
-        DISTORTIC_LEAVE = PokecubeLegends.BLOCKS_TAB.register("distortic_leave", () -> new LeavesBlock(Block.Properties
-                .from(Blocks.JUNGLE_LEAVES).notSolid()));
+        DISTORTIC_LEAVE = PokecubeLegends.BLOCKS_TAB.register("distortic_leave", () -> new LeavesBlock(Block.Properties.create(
+                Material.LEAVES, MaterialColor.PURPLE).hardnessAndResistance(1f, 5).sound(SoundType.PLANT).notSolid()));
         DISTORTIC_LOG = PokecubeLegends.BLOCKS_TAB.register("distortic_log", () -> Blocks.createLogBlock(
-                MaterialColor.PURPLE, MaterialColor.BLUE));
+                MaterialColor.BLUE, MaterialColor.BLUE));
         DISTORTIC_WOOD = PokecubeLegends.BLOCKS_TAB.register("distortic_wood", () -> Blocks.createLogBlock(
-                MaterialColor.PURPLE, MaterialColor.BLUE));
+                MaterialColor.BLUE, MaterialColor.BLUE));
         STRIP_DISTORTIC_LOG = PokecubeLegends.BLOCKS_TAB.register("stripped_distortic_log", () -> Blocks.createLogBlock(
-                MaterialColor.PURPLE, MaterialColor.BLUE));
+                MaterialColor.BLUE, MaterialColor.BLUE));
         STRIP_DISTORTIC_WOOD = PokecubeLegends.BLOCKS_TAB.register("stripped_distortic_wood", () -> Blocks
-                .createLogBlock(MaterialColor.PURPLE, MaterialColor.BLUE));
-        DISTORTIC_PLANK = PokecubeLegends.BLOCKS_TAB.register("distortic_plank", () -> new Block(Block.Properties.from(
-                Blocks.OAK_PLANKS)));
+                .createLogBlock(MaterialColor.BLUE, MaterialColor.BLUE));
+        DISTORTIC_PLANK = PokecubeLegends.BLOCKS_TAB.register("distortic_plank", () -> new Block(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BLUE).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         DISTORTIC_STAIRS = PokecubeLegends.BLOCKS_TAB.register("distortic_stairs",
-                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.from(
-                        Blocks.OAK_PLANKS).sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f)));
-        DISTORTIC_SLAB = PokecubeLegends.BLOCKS_TAB.register("distortic_slab", () -> new SlabBlock(Block.Properties
-                .from(Blocks.OAK_SLAB)));
-        DISTORTIC_FENCE = PokecubeLegends.BLOCKS_TAB.register("distortic_fence", () -> new FenceBlock(Block.Properties
-                .from(Blocks.OAK_FENCE)));
-        DISTORTIC_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("distortic_fence_gate", () -> new FenceGateBlock(
-                Block.Properties.from(Blocks.OAK_FENCE_GATE)));
+                () -> new ItemGenerator.GenericWoodStairs(Blocks.OAK_STAIRS.getDefaultState(), Block.Properties.create(
+                		Material.WOOD, MaterialColor.BLUE).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        DISTORTIC_SLAB = PokecubeLegends.BLOCKS_TAB.register("distortic_slab", () -> new SlabBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BLUE).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        DISTORTIC_FENCE = PokecubeLegends.BLOCKS_TAB.register("distortic_fence", () -> new FenceBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BLUE).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
+        DISTORTIC_FENCE_GATE = PokecubeLegends.BLOCKS_TAB.register("distortic_fence_gate", () -> new FenceGateBlock(Block.Properties.create(
+        		Material.WOOD, MaterialColor.BLUE).hardnessAndResistance(2.0F).sound(SoundType.WOOD)));
         DISTORTIC_PR_PLATE = PokecubeLegends.BLOCKS_TAB.register("distortic_pressure_plate",
                 () -> new ItemGenerator.GenericPressurePlate(PressurePlateBlock.Sensitivity.EVERYTHING, Block.Properties
-                        .create(Material.WOOD).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
+                        .create(Material.WOOD, MaterialColor.BLUE).sound(SoundType.WOOD).doesNotBlockMovement().hardnessAndResistance(
                                 0.5F)));
         DISTORTIC_BUTTON = PokecubeLegends.BLOCKS_TAB.register("distortic_button",
-                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD).sound(SoundType.WOOD)
+                () -> new ItemGenerator.GenericWoodButton(Block.Properties.create(Material.WOOD, MaterialColor.BLUE).sound(SoundType.WOOD)
                         .doesNotBlockMovement().hardnessAndResistance(0.5F)));
         DISTORTIC_TRAPDOOR = PokecubeLegends.BLOCKS_TAB.register("distortic_trapdoor",
-                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.WOOD)
+                () -> new ItemGenerator.GenericTrapDoor(Block.Properties.create(Material.WOOD, MaterialColor.BLUE)
                         .sound(SoundType.WOOD).hardnessAndResistance(2.0f, 3.0f).notSolid()));
         DISTORTIC_DOOR = PokecubeLegends.BLOCKS_TAB.register("distortic_door", () -> new ItemGenerator.GenericDoor(
-                Block.Properties.create(Material.WOOD, MaterialColor.WOOD).sound(SoundType.WOOD).hardnessAndResistance(
+                Block.Properties.create(Material.WOOD, MaterialColor.BLUE).sound(SoundType.WOOD).hardnessAndResistance(
                         2.0f, 3.0f).notSolid()));
 
         // Mirage Spot (Hoppa Ring)
         BLOCK_PORTALWARP = PokecubeLegends.BLOCKS.register("portal", () -> new PortalWarp("portal", Block.Properties
-                .create(Material.ROCK).sound(SoundType.METAL).hardnessAndResistance(2000, 2000)).setShape(VoxelShapes
+                .create(Material.ROCK, MaterialColor.GOLD).sound(SoundType.METAL).hardnessAndResistance(2000, 2000)).setShape(VoxelShapes
                         .create(0.05, 0, 0.05, 1, 3, 1)).setInfoBlockName("portalwarp"));
 
         // Legendary Spawns
-        GOLEM_STONE = PokecubeLegends.BLOCKS.register("golem_stone", () -> new BlockBase("golem_stone", Material.ROCK,
-                5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+        GOLEM_STONE = PokecubeLegends.BLOCKS.register("golem_stone", () -> new BlockBase("golem_stone", Material.ROCK, 
+        		MaterialColor.WHITE_TERRACOTTA, 5f, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
 
         LEGENDARY_SPAWN = PokecubeLegends.BLOCKS.register("legendaryspawn", () -> new LegendaryBlock("legendaryspawn",
-                Material.IRON).noInfoBlock());
+                Material.IRON, MaterialColor.GOLD).noInfoBlock());
         TROUGH_BLOCK = PokecubeLegends.BLOCKS.register("trough_block", () -> new TroughBlock("trough_block",
-                Block.Properties.create(Material.IRON).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
+                Block.Properties.create(Material.IRON, MaterialColor.BROWN).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
                         .harvestLevel(2).sound(SoundType.ANVIL).setLightLevel(b -> 4).variableOpacity()).noInfoBlock());
         HEATRAN_BLOCK 	= PokecubeLegends.BLOCKS.register("heatran_block", () -> new HeatranBlock("heatran_block",
-        		Block.Properties.create(Material.LAVA).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
-                .harvestLevel(2).sound(SoundType.CORAL).setLightLevel(b -> 4).variableOpacity().setEmmisiveRendering((s, r, p) -> true)).noInfoBlock());
+        		Block.Properties.create(Material.LAVA, MaterialColor.NETHERRACK).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
+                .harvestLevel(2).sound(SoundType.NETHER_BRICK).setLightLevel(b -> 4).variableOpacity().setEmmisiveRendering((s, r, p) -> true)).noInfoBlock());
         TAO_BLOCK 	= PokecubeLegends.BLOCKS.register("blackwhite_block", () -> new TaoTrioBlock("blackwhite_block",
-        		Block.Properties.create(Material.ANVIL).hardnessAndResistance(5, 15).sound(SoundType.FUNGUS)
+        		Block.Properties.create(Material.ANVIL, MaterialColor.SNOW).hardnessAndResistance(5, 15).sound(SoundType.FUNGUS)
         				.variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 1, 1)).noInfoBlock());
         
         // Regi Cores
         REGISTEEL_CORE = PokecubeLegends.BLOCKS.register("registeel_spawn", () -> new Registeel_Core("registeel_spawn",
-                Material.IRON, 15, SoundType.METAL, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.IRON, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.METAL, ToolType.PICKAXE, 2).noInfoBlock());
         REGICE_CORE = PokecubeLegends.BLOCKS.register("regice_spawn", () -> new Regice_Core("regice_spawn",
-                Material.PACKED_ICE, 15, SoundType.GLASS, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.PACKED_ICE, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.GLASS, ToolType.PICKAXE, 2).noInfoBlock());
         REGIROCK_CORE = PokecubeLegends.BLOCKS.register("regirock_spawn", () -> new Regirock_Core("regirock_spawn",
-                Material.ROCK, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.ROCK, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         REGIELEKI_CORE = PokecubeLegends.BLOCKS.register("regieleki_spawn", () -> new Regieleki_Core("regieleki_spawn",
-                Material.ROCK, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.ROCK, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         REGIDRAGO_CORE = PokecubeLegends.BLOCKS.register("regidrago_spawn", () -> new Regidrago_Core("regidrago_spawn",
-                Material.ROCK, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.ROCK, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.STONE, ToolType.PICKAXE, 2).noInfoBlock());
         REGIGIGA_CORE = PokecubeLegends.BLOCKS.register("regigiga_spawn", () -> new Regigigas_Core("regigiga_spawn",
-                Material.IRON, 15, SoundType.METAL, ToolType.PICKAXE, 2).noInfoBlock());
+                Material.IRON, MaterialColor.WHITE_TERRACOTTA, 15, SoundType.METAL, ToolType.PICKAXE, 2).noInfoBlock());
         //
         
         TIMESPACE_CORE = PokecubeLegends.BLOCKS.register("timerspawn", () -> new SpaceCoreBlock("timerspawn",
-                Block.Properties.create(Material.ORGANIC).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
+                Block.Properties.create(Material.ORGANIC, MaterialColor.STONE).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
                         .variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 2, 1)).noInfoBlock());
         NATURE_CORE = PokecubeLegends.BLOCKS.register("naturespawn", () -> new NatureCoreBlock("naturespawn",
-                Block.Properties.create(Material.ROCK).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
+                Block.Properties.create(Material.ROCK, MaterialColor.WHITE_TERRACOTTA).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
                         .variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 2, 1)).noInfoBlock());
         KELDEO_CORE = PokecubeLegends.BLOCKS.register("keldeoblock", () -> new KeldeoBlock("keldeoblock",
-                Block.Properties.create(Material.ROCK).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
+                Block.Properties.create(Material.ROCK, MaterialColor.BLUE).hardnessAndResistance(2000, 2000).sound(SoundType.STONE)
                         .variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 1, 1)).noInfoBlock());
         VICTINI_CORE = PokecubeLegends.BLOCKS.register("victiniblock", () -> new VictiniBlock("victiniblock",
-                Block.Properties.create(Material.IRON).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
+                Block.Properties.create(Material.IRON, MaterialColor.GOLD).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
                         .harvestLevel(2).sound(SoundType.ANVIL).variableOpacity()).setShape(VoxelShapes.create(0.05, 0,
                                 0.05, 1, 1, 1)).noInfoBlock());
         YVELTAL_CORE = PokecubeLegends.BLOCKS.register("yveltal_egg", () -> new YveltalEgg("yveltal_egg",
-                Block.Properties.create(Material.IRON).hardnessAndResistance(2000, 2000).sound(SoundType.WOOD)
+                Block.Properties.create(Material.IRON, MaterialColor.BLACK).hardnessAndResistance(2000, 2000).sound(SoundType.WOOD)
                         .variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 2, 1)).noInfoBlock());
         XERNEAS_CORE = PokecubeLegends.BLOCKS.register("xerneas_tree", () -> new XerneasCore("xerneas_tree",
-                Block.Properties.create(Material.IRON).hardnessAndResistance(2000, 2000).sound(SoundType.WOOD)
+                Block.Properties.create(Material.IRON, MaterialColor.SNOW).hardnessAndResistance(2000, 2000).sound(SoundType.WOOD)
                         .variableOpacity()).setShape(VoxelShapes.create(0.05, 0, 0.05, 1, 2, 1)).noInfoBlock());
 
         // Ores
         RUBY_ORE = PokecubeLegends.BLOCKS.register("ruby_ore", () -> new BlockBase("ruby_ore", Block.Properties.create(
-                Material.ROCK).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
+                Material.ROCK, MaterialColor.STONE).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
                 .harvestLevel(2)).noInfoBlock());
         SAPPHIRE_ORE = PokecubeLegends.BLOCKS.register("sapphire_ore", () -> new BlockBase("sapphire_ore",
-                Block.Properties.create(Material.ROCK).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(
+                Block.Properties.create(Material.ROCK, MaterialColor.STONE).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(
                         ToolType.PICKAXE).harvestLevel(2)).noInfoBlock());
         RUBY_BLOCK = PokecubeLegends.BLOCKS.register("ruby_block", () -> new Block(Block.Properties.create(
-                Material.IRON).hardnessAndResistance(1.5f, 10).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)));
+                Material.IRON, MaterialColor.RED).hardnessAndResistance(1.5f, 10).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)));
         SAPPHIRE_BLOCK = PokecubeLegends.BLOCKS.register("sapphire_block", () -> new Block(Block.Properties.create(
-                Material.IRON).hardnessAndResistance(1.5f, 10).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)));
+                Material.IRON, MaterialColor.BLUE).hardnessAndResistance(1.5f, 10).sound(SoundType.METAL).harvestTool(ToolType.PICKAXE)));
         SPECTRUM_ORE = PokecubeLegends.BLOCKS_TAB.register("spectrum_ore", () -> new BlockBase("spectrum_ore",
-                Block.Properties.create(Material.ROCK).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(
+                Block.Properties.create(Material.ROCK, MaterialColor.CYAN_TERRACOTTA).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(
                         ToolType.PICKAXE).harvestLevel(2)).noInfoBlock());
         SPECTRUM_BLOCK = PokecubeLegends.BLOCKS_TAB.register("spectrum_block", () -> new Block(Block.Properties.create(
-                Material.IRON).hardnessAndResistance(5.0f, 7).sound(SoundType.ANVIL).setLightLevel(b -> 4).harvestTool(
+                Material.IRON, MaterialColor.ADOBE).hardnessAndResistance(5.0f, 7).sound(SoundType.METAL).setLightLevel(b -> 4).harvestTool(
                         ToolType.PICKAXE)));
 
         // COSMIC_DUST_ORE =
@@ -511,7 +515,7 @@ public class BlockInit
         // 15).harvestTool(
         // ToolType.PICKAXE).harvestLevel(2)).noInfoBlock());
         COSMIC_DUST_ORE = PokecubeLegends.BLOCKS_TAB.register("cosmic_dust_ore", () -> new FallingBlock(Block.Properties
-                .create(Material.ROCK).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
+                .create(Material.ROCK, MaterialColor.BLUE_TERRACOTTA).sound(SoundType.STONE).hardnessAndResistance(5, 15).harvestTool(ToolType.PICKAXE)
                 .harvestLevel(2)));
 
     }

--- a/src/main/java/pokecube/legends/init/PlantsInit.java
+++ b/src/main/java/pokecube/legends/init/PlantsInit.java
@@ -3,6 +3,7 @@ package pokecube.legends.init;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.material.MaterialColor;
 import net.minecraftforge.fml.RegistryObject;
 import pokecube.legends.PokecubeLegends;
 import pokecube.legends.blocks.PlantBase;
@@ -18,14 +19,14 @@ public class PlantsInit
 
     static
     {
-        PlantsInit.MUSH_PLANT1 = PokecubeLegends.BLOCKS_TAB.register("mush_plant1", () -> new PlantBase(Material.PLANTS,
-                0f, 3f, SoundType.PLANT));
+        PlantsInit.MUSH_PLANT1 = PokecubeLegends.BLOCKS_TAB.register("mush_plant1", () -> new PlantBase(Material.PLANTS, 
+        		MaterialColor.PURPLE, 0f, 3f, SoundType.PLANT));
         PlantsInit.MUSH_PLANT2 = PokecubeLegends.BLOCKS_TAB.register("mush_plant2", () -> new PlantBase(Material.PLANTS,
-                0f, 3f, SoundType.PLANT));
+        		MaterialColor.PURPLE, 0f, 3f, SoundType.PLANT));
         PlantsInit.AGED_FLOWER = PokecubeLegends.BLOCKS_TAB.register("a1_flower", () -> new PlantBase(Material.PLANTS,
-                0f, 3f, SoundType.CORAL));
+        		MaterialColor.YELLOW, 0f, 3f, SoundType.CORAL));
         PlantsInit.DIRST_FLOWER = PokecubeLegends.BLOCKS_TAB.register("b1_flower", () -> new PlantBase(Material.PLANTS,
-                0f, 3f, SoundType.BAMBOO_SAPLING));
+        		MaterialColor.PINK, 0f, 3f, SoundType.BAMBOO_SAPLING));
     }
 
     public static void registry() {

--- a/src/main/java/pokecube/mobs/PokecubeMobs.java
+++ b/src/main/java/pokecube/mobs/PokecubeMobs.java
@@ -61,6 +61,7 @@ import pokecube.core.interfaces.IPokemob.Stats;
 import pokecube.core.interfaces.capabilities.CapabilityPokemob;
 import pokecube.core.interfaces.pokemob.ai.GeneralStates;
 import pokecube.core.items.berries.BerryManager;
+import pokecube.core.items.berries.ItemBerry.BerryType;
 import pokecube.core.items.pokecubes.EntityPokecube;
 import pokecube.core.items.pokecubes.PokecubeManager;
 import pokecube.core.utils.Tools;
@@ -329,19 +330,74 @@ public class PokecubeMobs
     public void registerItems(final RegisterMiscItems event)
     {
 
-        ItemGenerator.berryWoods.put("pecha", MaterialColor.PINK);
-        ItemGenerator.berryWoods.put("oran", MaterialColor.BLUE);
+        ItemGenerator.berryWoods.put("pecha", MaterialColor.MAGENTA);
+        ItemGenerator.berryWoods.put("oran", MaterialColor.LIGHT_BLUE);
         ItemGenerator.berryWoods.put("leppa", MaterialColor.RED);
-        ItemGenerator.berryWoods.put("sitrus", MaterialColor.YELLOW);
+        ItemGenerator.berryWoods.put("sitrus", MaterialColor.YELLOW_TERRACOTTA);
         ItemGenerator.berryWoods.put("enigma", MaterialColor.BLACK);
-        ItemGenerator.berryWoods.put("nanab", MaterialColor.WHITE_TERRACOTTA);
+        ItemGenerator.berryWoods.put("nanab", MaterialColor.BROWN_TERRACOTTA);
 
-        ItemGenerator.onlyBerryLeaves.add("pomeg");
-        ItemGenerator.onlyBerryLeaves.add("kelpsy");
-        ItemGenerator.onlyBerryLeaves.add("qualot");
-        ItemGenerator.onlyBerryLeaves.add("hondew");
-        ItemGenerator.onlyBerryLeaves.add("grepa");
-        ItemGenerator.onlyBerryLeaves.add("tamato");
+        ItemGenerator.berryLeaves.put("pecha", MaterialColor.FOLIAGE);
+        ItemGenerator.berryLeaves.put("oran", MaterialColor.PINK_TERRACOTTA);
+        ItemGenerator.berryLeaves.put("leppa", MaterialColor.YELLOW_TERRACOTTA);
+        ItemGenerator.berryLeaves.put("sitrus", MaterialColor.LIGHT_BLUE_TERRACOTTA);
+        ItemGenerator.berryLeaves.put("enigma", MaterialColor.WHITE_TERRACOTTA);
+        ItemGenerator.berryLeaves.put("nanab", MaterialColor.LIGHT_BLUE);
+
+        ItemGenerator.onlyBerryLeaves.put("pomeg", MaterialColor.RED);
+        ItemGenerator.onlyBerryLeaves.put("kelpsy", MaterialColor.PINK);
+        ItemGenerator.onlyBerryLeaves.put("qualot", MaterialColor.FOLIAGE);
+        ItemGenerator.onlyBerryLeaves.put("hondew", MaterialColor.PURPLE);
+        ItemGenerator.onlyBerryLeaves.put("grepa", MaterialColor.RED);
+        ItemGenerator.onlyBerryLeaves.put("tamato", MaterialColor.LIGHT_BLUE);
+
+        ItemGenerator.berryCrops.put("aspear", MaterialColor.RED);
+        ItemGenerator.berryCrops.put("cheri", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("chesto", MaterialColor.PINK);
+        ItemGenerator.berryCrops.put("cornn", MaterialColor.PINK);
+        ItemGenerator.berryCrops.put("enigma", MaterialColor.WHITE_TERRACOTTA);
+        ItemGenerator.berryCrops.put("grepa", MaterialColor.RED);
+        ItemGenerator.berryCrops.put("hondew", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("jaboca", MaterialColor.PURPLE);
+        ItemGenerator.berryCrops.put("kelpsy", MaterialColor.PINK);
+        ItemGenerator.berryCrops.put("leppa", MaterialColor.YELLOW_TERRACOTTA);
+        ItemGenerator.berryCrops.put("lum", MaterialColor.PURPLE);
+        ItemGenerator.berryCrops.put("nanab", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryCrops.put("null", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("oran", MaterialColor.ADOBE);
+        ItemGenerator.berryCrops.put("pecha", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("persim", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryCrops.put("pinap", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("pomeg", MaterialColor.RED);
+        ItemGenerator.berryCrops.put("qualot", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("rawst", MaterialColor.FOLIAGE);
+        ItemGenerator.berryCrops.put("rowap", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryCrops.put("sitrus", MaterialColor.LIGHT_BLUE_TERRACOTTA);
+        ItemGenerator.berryCrops.put("tamato", MaterialColor.LIGHT_BLUE);
+
+        ItemGenerator.berryFruits.put("aspear", MaterialColor.RED);
+        ItemGenerator.berryFruits.put("cheri", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryFruits.put("chesto", MaterialColor.PINK);
+        ItemGenerator.berryFruits.put("cornn", MaterialColor.PINK);
+        ItemGenerator.berryFruits.put("enigma", MaterialColor.BLACK);
+        ItemGenerator.berryFruits.put("grepa", MaterialColor.YELLOW);
+        ItemGenerator.berryFruits.put("hondew", MaterialColor.LIME);
+        ItemGenerator.berryFruits.put("jaboca", MaterialColor.PURPLE);
+        ItemGenerator.berryFruits.put("kelpsy", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryFruits.put("leppa", MaterialColor.RED);
+        ItemGenerator.berryFruits.put("lum", MaterialColor.PURPLE);
+        ItemGenerator.berryFruits.put("nanab", MaterialColor.PINK);
+        ItemGenerator.berryFruits.put("null", MaterialColor.FOLIAGE);
+        ItemGenerator.berryFruits.put("oran", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryFruits.put("pecha", MaterialColor.PINK);
+        ItemGenerator.berryFruits.put("persim", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryFruits.put("pinap", MaterialColor.YELLOW);
+        ItemGenerator.berryFruits.put("pomeg", MaterialColor.ORANGE_TERRACOTTA);
+        ItemGenerator.berryFruits.put("qualot", MaterialColor.YELLOW);
+        ItemGenerator.berryFruits.put("rawst", MaterialColor.FOLIAGE);
+        ItemGenerator.berryFruits.put("rowap", MaterialColor.LIGHT_BLUE);
+        ItemGenerator.berryFruits.put("sitrus", MaterialColor.YELLOW);
+        ItemGenerator.berryFruits.put("tamato", MaterialColor.ORANGE_TERRACOTTA);
 
         ItemGenerator.variants.add("waterstone");
         ItemGenerator.variants.add("firestone");

--- a/src/main/resources/assets/pokecube_legends/models/block/portal.json
+++ b/src/main/resources/assets/pokecube_legends/models/block/portal.json
@@ -646,9 +646,9 @@
 			"scale": [0.1, 0.1, 0.1]
 		},
 		"gui": {
-			"rotation": [17, -32, 0],
-			"translation": [0, 0.25, -1],
-			"scale": [0.35, 0.35, 0.35]
+			"rotation": [30, 225, 0],
+			"translation": [0, 0.5, 0],
+			"scale": [0.32, 0.32, 0.32]
 		},
 		"head": {
 			"translation": [0, 0, -3.25]

--- a/src/main/resources/assets/pokecube_legends/models/item/portal.json
+++ b/src/main/resources/assets/pokecube_legends/models/item/portal.json
@@ -1,30 +1,39 @@
 {
-   "parent": "pokecube_legends:block/portal_on",
-  "display": {
-    "gui": {
-      "rotation": [ 30, 225, 0 ],
-      "translation": [ 0, -4, 0],
-      "scale":[ 0.25, 0.25, 0.25 ]
-    },
-    "fixed": {
-      "rotation": [ 0, 0, 0 ],
-      "translation": [ 0, 0, 0],
-      "scale":[ 0.5, 0.5, 0.5 ]
-    },
-    "thirdperson_righthand": {
-      "rotation": [ 75, 45, 0 ],
-      "translation": [ 0, 2.5, 0],
-      "scale": [ 0.375, 0.375, 0.375 ]
-    },
-    "firstperson_righthand": {
-      "rotation": [ 0, 45, 0 ],
-      "translation": [ 0, 0, 0 ],
-      "scale": [ 0.40, 0.40, 0.40 ]
-    },
-    "firstperson_lefthand": {
-      "rotation": [ 0, 225, 0 ],
-      "translation": [ 0, 0, 0 ],
-      "scale": [ 0.40, 0.40, 0.40 ]
-    }
-  }
+   	"parent": "pokecube_legends:block/portal",
+   	"display": {
+		"thirdperson_righthand": {
+			"rotation": [45, 0, 0],
+			"translation": [0, -0.25, -0.5],
+			"scale": [0.35, 0.35, 0.35]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [45, 0, 0],
+			"translation": [0, -0.25, -0.5],
+			"scale": [0.35, 0.35, 0.35]
+		},
+		"firstperson_righthand": {
+			"rotation": [0, 8, 0],
+			"translation": [0, 0.25, -1],
+			"scale": [0.35, 0.35, 0.35]
+		},
+		"firstperson_lefthand": {
+			"rotation": [0, 8, 0],
+			"translation": [0, 0.25, -1],
+			"scale": [0.35, 0.35, 0.35]
+		},
+		"ground": {
+			"scale": [0.1, 0.1, 0.1]
+		},
+		"gui": {
+			"rotation": [30, 225, 0],
+			"translation": [0, 0.5, 0],
+			"scale": [0.32, 0.32, 0.32]
+		},
+		"head": {
+			"translation": [0, 0, -3.25]
+		},
+		"fixed": {
+			"scale": [0.35, 0.35, 0.35]
+		}
+	}
 }


### PR DESCRIPTION
- Blocks now use different map colors besides the default stone or wood color.
- Fix incorrect Mirage Spot inventory model.
- Fix not being able to walk through the infected torch.