### PR TITLE
updates some spawns

### DIFF
--- a/src/main/java/pokecube/core/database/pokedex/PokedexEntryLoader.java
+++ b/src/main/java/pokecube/core/database/pokedex/PokedexEntryLoader.java
@@ -364,7 +364,7 @@ public class PokedexEntryLoader
     {
         public Map<String, String> values = Maps.newHashMap();
 
-        protected DefaultFormeHolder model = null;
+        public DefaultFormeHolder model = null;
 
         private String __cache__ = null;
 

--- a/src/main/java/pokecube/core/database/spawns/PokemobSpawns.java
+++ b/src/main/java/pokecube/core/database/spawns/PokemobSpawns.java
@@ -14,6 +14,7 @@ import pokecube.core.PokecubeCore;
 import pokecube.core.database.Database;
 import pokecube.core.database.PokedexEntry;
 import pokecube.core.database.pokedex.PokedexEntryLoader;
+import pokecube.core.database.pokedex.PokedexEntryLoader.DefaultFormeHolder;
 import pokecube.core.database.pokedex.PokedexEntryLoader.SpawnRule;
 import pokecube.core.database.resources.PackFinder;
 import pokecube.core.database.util.DataHelpers;
@@ -49,6 +50,7 @@ public class PokemobSpawns extends ResourceData
         public float rate = 0;
         public int level = -1;
         public String variance;
+        public String variant = "";
     }
 
     private static final SpawnList MASTER_LIST = new SpawnList();
@@ -154,6 +156,13 @@ public class PokemobSpawns extends ResourceData
                     if (poke != null)
                     {
                         SpawnRule customRule = frule.copy();
+
+                        if (!mob.variant.isBlank())
+                        {
+                            customRule.model = new DefaultFormeHolder();
+                            customRule.model.key = mob.variant;
+                        }
+
                         customRule.values.put("min", mob.min + "");
                         customRule.values.put("max", mob.max + "");
                         customRule.values.put("rate", mob.rate + "");

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_formes.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_formes.json
@@ -629,6 +629,20 @@
     },
     {
       "name": "shellos",
+      "models": [
+        {
+          "key": "shellos_east",
+          "tex": "shellos_east",
+          "model": "shellos_east",
+          "anim": "shellos_east"
+        },
+        {
+          "key": "shellos_west",
+          "tex": "shellos_west",
+          "model": "shellos_west",
+          "anim": "shellos_west"
+        }
+      ],
       "model": {
         "key": "shellos_east",
         "tex": "shellos_east",
@@ -770,6 +784,20 @@
     },
     {
       "name": "basculin",
+      "models": [
+        {
+          "key": "basculin_red",
+          "tex": "basculin_red",
+          "model": "basculin_red",
+          "anim": "basculin_red"
+        },
+        {
+          "key": "basculin_blue",
+          "tex": "basculin_blue",
+          "model": "basculin_blue",
+          "anim": "basculin_blue"
+        }
+      ],
       "model": {
         "key": "basculin_red",
         "tex": "basculin_red",
@@ -784,6 +812,32 @@
     },
     {
       "name": "deerling",
+      "models": [
+        {
+          "key": "deerling_sp",
+          "tex": "deerling_sp",
+          "model": "deerling_sp",
+          "anim": "deerling_sp"
+        },
+        {
+          "key": "deerling_au",
+          "tex": "deerling_au",
+          "model": "deerling_au",
+          "anim": "deerling_au"
+        },
+        {
+          "key": "deerling_su",
+          "tex": "deerling_su",
+          "model": "deerling_su",
+          "anim": "deerling_su"
+        },
+        {
+          "key": "deerling_wi",
+          "tex": "deerling_wi",
+          "model": "deerling_wi",
+          "anim": "deerling_wi"
+        }
+      ],
       "model": {
         "key": "deerling_sp",
         "tex": "deerling_sp",
@@ -793,6 +847,32 @@
     },
     {
       "name": "sawsbuck",
+      "models": [
+        {
+          "key": "sawsbuck_sp",
+          "tex": "sawsbuck_sp",
+          "model": "sawsbuck_sp",
+          "anim": "sawsbuck_sp"
+        },
+        {
+          "key": "sawsbuck_au",
+          "tex": "sawsbuck_au",
+          "model": "sawsbuck_au",
+          "anim": "sawsbuck_au"
+        },
+        {
+          "key": "sawsbuck_su",
+          "tex": "sawsbuck_su",
+          "model": "sawsbuck_su",
+          "anim": "sawsbuck_su"
+        },
+        {
+          "key": "sawsbuck_wi",
+          "tex": "sawsbuck_wi",
+          "model": "sawsbuck_wi",
+          "anim": "sawsbuck_wi"
+        }
+      ],
       "model": {
         "key": "sawsbuck_sp",
         "tex": "sawsbuck_sp",

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_interacts.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_interacts.json
@@ -6716,10 +6716,7 @@
             "evoMoves": "hornleech",
             "form_from": "deerling_sp",
             "model": {
-              "key": "sawsbuck_sp",
-              "tex": "sawsbuck_sp",
-              "model": "sawsbuck_sp",
-              "anim": "sawsbuck_sp"
+              "key": "sawsbuck_sp"
             }
           },
           {
@@ -6728,10 +6725,7 @@
             "evoMoves": "hornleech",
             "form_from": "deerling_su",
             "model": {
-              "key": "sawsbuck_su",
-              "tex": "sawsbuck_su",
-              "model": "sawsbuck_su",
-              "anim": "sawsbuck_su"
+              "key": "sawsbuck_su"
             }
           },
           {
@@ -6740,10 +6734,7 @@
             "evoMoves": "hornleech",
             "form_from": "deerling_wi",
             "model": {
-              "key": "sawsbuck_wi",
-              "tex": "sawsbuck_wi",
-              "model": "sawsbuck_wi",
-              "anim": "sawsbuck_wi"
+              "key": "sawsbuck_wi"
             }
           },
           {
@@ -6752,10 +6743,7 @@
             "evoMoves": "hornleech",
             "form_from": "deerling_au",
             "model": {
-              "key": "sawsbuck_au",
-              "tex": "sawsbuck_au",
-              "model": "sawsbuck_au",
-              "anim": "sawsbuck_au"
+              "key": "sawsbuck_au"
             }
           }
         ]

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_spawns.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/pokemobs_spawns.json
@@ -114,15 +114,6 @@
         "spawnRules": [
           {
             "values": {
-              "types": "ruin",
-              "rate": "0.5"
-            },
-            "model": {
-              "key": "unown_*"
-            }
-          },
-          {
-            "values": {
               "biomes": "pokecube_legends:distorted_lands, pokecube_legends:small_distorted_islands",
               "rate": "0.3"
             },
@@ -218,101 +209,6 @@
               "min": "1",
               "rate": "0.002",
               "max": "1"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "shellos",
-      "stats": {
-        "spawnRules": [
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "ocean,cave",
-              "rate": "0.1",
-              "water": "true"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "beach,cave",
-              "rate": "0.1",
-              "water": "true"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "category": "ocean",
-              "rate": "0.2",
-              "water": "true"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "beach",
-              "rate": "0.2",
-              "water": "true"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "ocean,cave",
-              "rate": "0.1",
-              "water": "true"
-            },
-            "model": {
-              "key": "shellos_west",
-              "tex": "shellos_west",
-              "model": "shellos_west",
-              "anim": "shellos_west"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "beach,cave",
-              "rate": "0.1",
-              "water": "true"
-            },
-            "model": {
-              "key": "shellos_west",
-              "tex": "shellos_west",
-              "model": "shellos_west",
-              "anim": "shellos_west"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "category": "ocean",
-              "rate": "0.2",
-              "water": "true"
-            },
-            "model": {
-              "key": "shellos_west",
-              "tex": "shellos_west",
-              "model": "shellos_west",
-              "anim": "shellos_west"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "beach",
-              "rate": "0.2",
-              "water": "true"
-            },
-            "model": {
-              "key": "shellos_west",
-              "tex": "shellos_west",
-              "model": "shellos_west",
-              "anim": "shellos_west"
             }
           }
         ]
@@ -499,61 +395,6 @@
               "tex": "basculin_blue",
               "model": "basculin_blue",
               "anim": "basculin_blue"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "deerling",
-      "stats": {
-        "spawnRules": [
-          {
-            "values": {
-              "types": "flower",
-              "rate": "0.11"
-            },
-            "model": {
-              "key": "deerling_sp",
-              "tex": "deerling_sp",
-              "model": "deerling_sp",
-              "anim": "deerling_sp"
-            }
-          },
-          {
-            "values": {
-              "category": "plains",
-              "rate": "0.11"
-            },
-            "model": {
-              "key": "deerling_au",
-              "tex": "deerling_au",
-              "model": "deerling_au",
-              "anim": "deerling_au"
-            }
-          },
-          {
-            "values": {
-              "category": "forest",
-              "rate": "0.11"
-            },
-            "model": {
-              "key": "deerling_su",
-              "tex": "deerling_su",
-              "model": "deerling_su",
-              "anim": "deerling_su"
-            }
-          },
-          {
-            "values": {
-              "types": "snowy",
-              "rate": "0.1"
-            },
-            "model": {
-              "key": "deerling_wi",
-              "tex": "deerling_wi",
-              "model": "deerling_wi",
-              "anim": "deerling_wi"
             }
           }
         ]
@@ -824,63 +665,6 @@
               "min": "1",
               "rate": "0.2",
               "max": "1"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "name": "sinistea",
-      "stats": {
-        "spawnRules": [
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "spooky",
-              "rate": "0.02"
-            },
-            "model": {
-              "key": "sinistea_nofake",
-              "tex": "sinistea",
-              "model": "sinistea_nofake",
-              "anim": "sinistea"
-            }
-          },
-          {
-            "values": {
-              "types": "village",
-              "rate": "0.01"
-            },
-            "model": {
-              "key": "sinistea_nofake",
-              "tex": "sinistea",
-              "model": "sinistea_nofake",
-              "anim": "sinistea"
-            }
-          },
-          {
-            "values": {
-              "typesBlacklist": "cold",
-              "types": "spooky",
-              "rate": "0.2"
-            },
-            "model": {
-              "key": "sinistea_fake",
-              "tex": "sinistea",
-              "model": "sinistea_fake",
-              "anim": "sinistea"
-            }
-          },
-          {
-            "values": {
-              "types": "village",
-              "rate": "0.1"
-            },
-            "model": {
-              "key": "sinistea_fake",
-              "tex": "sinistea",
-              "model": "sinistea_fake",
-              "anim": "sinistea"
             }
           }
         ]

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/cold_snowy.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/cold_snowy.json
@@ -32,7 +32,9 @@
       "entries": [
         {"key": "nickit","min": 2,"max": 4,"rate": 0.3},
         {"key": "sneasel","min": 2,"max": 4,"rate": 0.2},
-        {"key": "jynx","min": 2,"max": 4,"rate": 0.2}
+        {"key": "jynx","min": 2,"max": 4,"rate": 0.2},
+        
+        {"key": "deerling","min": 2,"max": 4,"rate": 0.11, "variant": "deerling_wi"}
       ]
     }
   ]

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/flowers.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/flowers.json
@@ -10,6 +10,8 @@
         {"key": "oricorio_pom-pom","min": 5,"max": 10,"rate": 0.7},
         {"key": "oricorio_sensu","min": 5,"max": 10,"rate": 0.7},
         
+        {"key": "deerling","min": 2,"max": 4,"rate": 0.11, "variant": "deerling_sp"},
+        
         {"key": "shaymin_land","min": 1,"max": 1,"rate": 0.002}
       ]
     },

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/forests.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/forests.json
@@ -96,6 +96,8 @@
         
         {"key": "girafarig","min": 2,"max": 4,"rate": 0.2},
         
+        {"key": "deerling","min": 2,"max": 4,"rate": 0.11, "variant": "deerling_su"},
+        
         {"key": "pansage","min": 2,"max": 4,"rate": 0.1},
         {"key": "pansear","min": 2,"max": 4,"rate": 0.1},
         {"key": "panpour","min": 2,"max": 4,"rate": 0.1},

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/nether_spooky.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/nether_spooky.json
@@ -70,6 +70,14 @@
       "entries": [
         {"key": "spiritomb","min": 2,"max": 4,"rate": 0.2}
       ]
+    },
+    {
+      "and_preset": "spooky_areas",
+      "not_preset": "cold_areas",
+      "entries": [
+        {"key": "sinistea","min": 2,"max": 4,"rate": 0.2, "variant": "sinistea_fake"},
+        {"key": "sinistea","min": 2,"max": 4,"rate": 0.02, "variant": "sinistea_nofake"}
+      ]
     }
   ]
 }

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/oceans_beaches.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/oceans_beaches.json
@@ -10,6 +10,14 @@
       ]
     },
     {
+      "and_preset": "oceans",
+      "not_preset": "cold_areas",
+      "entries": [
+        {"key": "shellos","min": 2,"max": 4,"rate": 0.1, "variant": "shellos_west"},
+        {"key": "shellos","min": 2,"max": 4,"rate": 0.1, "variant": "shellos_east"}
+      ]
+    },
+    {
       "and_preset": "ocean_ground",
       "entries": [
         {"key": "wingull","min": 2,"max": 4,"rate": 0.5},
@@ -83,6 +91,14 @@
         {"key": "piplup","min": 1,"max": 2,"rate": 0.01},
         {"key": "popplio","min": 1,"max": 2,"rate": 0.01},
         {"key": "sobble","min": 1,"max": 2,"rate": 0.01}
+      ]
+    },
+    {
+      "and_preset": "oceans",
+      "not_preset": "cold_areas",
+      "entries": [
+        {"key": "shellos","min": 2,"max": 4,"rate": 0.1, "variant": "shellos_west"},
+        {"key": "shellos","min": 2,"max": 4,"rate": 0.1, "variant": "shellos_east"}
       ]
     },
     {

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/plains.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/plains.json
@@ -84,6 +84,8 @@
         
         {"key": "bellsprout","min": 2,"max": 4,"rate": 0.2},
         
+        {"key": "deerling","min": 2,"max": 4,"rate": 0.11, "variant": "deerling_au"},
+        
         {"key": "exeggcute","min": 4,"max": 8,"rate": 0.08},
         {"key": "combee","min": 4,"max": 8,"rate": 0.06},
         

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/ruins.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/ruins.json
@@ -3,6 +3,8 @@
     {
       "and_preset": "ruins",
       "entries": [
+        {"key": "unown","min": 2,"max": 4,"rate": 0.5, "variant": "unown_*"},
+        
         {"key": "klefki","min": 2,"max": 4,"rate": 0.2},
         {"key": "honedge","min": 2,"max": 4,"rate": 0.2},
         

--- a/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/villages.json
+++ b/src/main/resources/data/pokecube_mobs/database/pokemobs/spawns/villages.json
@@ -28,6 +28,9 @@
         {"key": "tyrogue","min": 2,"max": 4,"rate": 0.08},
         {"key": "scraggy","min": 2,"max": 4,"rate": 0.08},
         
+        {"key": "sinistea","min": 2,"max": 4,"rate": 0.1, "variant": "sinistea_fake"},
+        
+        {"key": "sinistea","min": 2,"max": 4,"rate": 0.01, "variant": "sinistea_nofake"},
         {"key": "smeargle","min": 2,"max": 4,"rate": 0.01},
         
         {"key": "volcanion","min": 1,"max": 1,"rate": 0.002},


### PR DESCRIPTION
updates shellos, deerling, sinistea, and unown to using the new spawn format.

Adds support for special models to the new spawn format, by specifiying "variant", this takes the key for the model from the other database files

Moves some of the model definitions to pokemobs_formes